### PR TITLE
Adjust and fix HTML doc generation

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-# A MonetDB driver for Elixir
+# Monet
+
+[![hex.pm](https://img.shields.io/hexpm/v/monet.svg)](https://hex.pm/packages/monet)
+[![hex.pm](https://img.shields.io/hexpm/dt/monet.svg)](https://hex.pm/packages/monet)
+[![hex.pm](https://img.shields.io/hexpm/l/monet.svg)](https://hex.pm/packages/monet)
+[![github.com](https://img.shields.io/github/last-commit/karlseguin/monet.svg)](https://github.com/karlseguin/monet)
+
+A [MonetDB](https://www.monetdb.org/) driver for Elixir
 
 Warning: Early development.
 
 ## Usage
 
-In your mix.exs file, add the project dependency:
+In your `mix.exs` file, add the project dependency:
 
 ```
 {:monet, "~> 0.1.2"}
 ```
 
-You can start a pool by adding `Monet` to your supervisor tree and providing configuration options:
+You can start a pool by adding `Monet` to your supervisor tree and providing
+configuration options:
 
 ```elixir
 opts = [
@@ -26,7 +34,7 @@ opts = [
 ]
 children = [
   ...
-  {Monet, opts} 
+  {Monet, opts}
 ]
 ```
 
@@ -40,9 +48,11 @@ You can then use the `Monet.query/1` and `Monet.query/2` functions:
 You can optionally use the `query!` variant.
 
 ### Named Pool
-When you create the pool, you have the option of providing a `name` This is useful in the case where you want to connect to multiple instances:
 
- ```elixir
+When you create the pool, you have the option of providing a `name` This is
+useful in the case where you want to connect to multiple instances:
+
+```elixir
 opts = [
   pool_size: 10,
   ...
@@ -58,9 +68,14 @@ When a named pool is used, the `query/2` and `query/3` functions must be used:
 ```
 
 ## Results
-On success, a `Monet.Result` structure is returned. The `rows` field exposes a list of list.
 
-`Monet.Result` also implements the Enumerable and Jason.Encoder protocols. By default, these simply enumerate or render `rows` as a list of lists. However, `Monet.as_map/1` can be used to change this behavior to iterate over a list of maps.
+On success, a `Monet.Result` structure is returned. The `rows` field exposes a
+list of list.
+
+`Monet.Result` also implements the Enumerable and Jason.Encoder protocols. By
+default, these simply enumerate or render `rows` as a list of lists. However,
+`Monet.as_map/1` can be used to change this behavior to iterate over a list of
+maps.
 
 ```elixir
 case Monet.as_map(Monet.query("select id, name from saiyans")) do
@@ -69,17 +84,23 @@ case Monet.as_map(Monet.query("select id, name from saiyans")) do
 end
 ```
 
-`as_map/1` is safe to chain with `Monet.query` as it will return any `{:error, _}` structure passed to it as-is.
+`as_map/1` is safe to chain with `Monet.query` as it will return any `{:error, _}`
+structure passed to it as-is.
 
-Note that `result.rows` does not change. It continues to be a listof lists. What does change is the Enumerable and Jason encoding behavior.
+Note that `result.rows` does not change. It continues to be a listof lists.
+What does change is the Enumerable and Jason encoding behavior.
 
 Optionally, `columns: :atoms` can be passed to `as_map`.
 
 
 ### Result Helpers
-`Monet.rows/1`, `Monet.rows!/1`, `Monet.row/1`, Monet.row!/1`, Monet.scalar/1`, `Monet.scalar!/1`, `Monet.map!/2` and `Monet.maps!/2` are all helpers that can help to turn a Result into more concrete structures.
 
-They're safe to use even if `Monet.query` returns an error (they simply return the error).
+`Monet.rows/1`, `Monet.rows!/1`, `Monet.row/1`, Monet.row!/1`, Monet.scalar/1`,
+`Monet.scalar!/1`, `Monet.map!/2` and `Monet.maps!/2` are all helpers that can
+help to turn a Result into more concrete structures.
+
+They're safe to use even if `Monet.query` returns an error (they simply return
+the error).
 
 ```elixir
 with {:ok, [a, b]} <- Monet.row(Monet.query("select 1, 2")) do
@@ -87,14 +108,19 @@ with {:ok, [a, b]} <- Monet.row(Monet.query("select 1, 2")) do
 end
 ```
 
-`row`, and `map` return an error if more the result has more than 1 row (the `row!` and `map!` variants raise). They return `nil` if there are no rows.
+`row`, and `map` return an error if more the result has more than 1 row (the
+`row!` and `map!` variants raise). They return `nil` if there are no rows.
 
-`scalar` and `scalar!` behaves the same, but also returns/raises if more there is more than 1 column.
+`scalar` and `scalar!` behaves the same, but also returns/raises if more there
+is more than 1 column.
 
-`map`, `map!`, `maps` and `maps!` accepts a second optional parameter, `columns: :atoms`.
+`map`, `map!`, `maps` and `maps!` accepts a second optional parameter,
+`columns: :atoms`.
 
 ## Transactions
-`Monet.transaction/1` and `Monet.transaction/2` (for named pools) can be used to wrap code in a transaction:
+
+`Monet.transaction/1` and `Monet.transaction/2` (for named pools) can be used
+to wrap code in a transaction:
 
 ```elixir
 Monet.transaction(fn tx ->
@@ -105,15 +131,18 @@ end)
 
 The function you provide can return:
 
-* `{:rollback, value}` - to rollback the transaction and return the same 2-value tuple
-* `{:commit, value}` - to commit the transaction and return `{:ok, value}`
-* `{:ok, value}` - to commit the transaction and return `{:ok, value}`
-* `value` - to commit the transaction and return `{:ok, value}`
+  * `{:rollback, value}` - to rollback the transaction and return the same 2-value tuple
+  * `{:commit, value}` - to commit the transaction and return `{:ok, value}`
+  * `{:ok, value}` - to commit the transaction and return `{:ok, value}`
+  * `value` - to commit the transaction and return `{:ok, value}`
 
 ## Prepared Statements
 Any calls to `query` which passes arguments will use a prepared statement.
 
-Special handling of prepared within a transaction is available. Using `Monet.prepare/3`, prepared statements can be registered with a given name and re-used. At the end of the transaction, the prepared statements are automatically deallocated.
+Special handling of prepared within a transaction is available. Using
+`Monet.prepare/3`, prepared statements can be registered with a given name and
+re-used. At the end of the transaction, the prepared statements are
+automatically deallocated.
 
 ```elixir
 Monet.transaction(fn tx ->
@@ -128,4 +157,12 @@ Monet.transaction(fn tx ->
 end)
 ```
 
-Keep in mind that MonetDB automatically deallocates prepared statements on execution error. This is why having automatically management of prepared statements at the transaction level makes sense (since a failure to execute probably means the transaction ends). It's much more complicated at the connection level (especially when you add the indirection of the pool).
+Keep in mind that MonetDB automatically deallocates prepared statements on
+execution error. This is why having automatically management of prepared
+statements at the transaction level makes sense (since a failure to execute
+probably means the transaction ends). It's much more complicated at the
+connection level (especially when you add the indirection of the pool).
+
+## License
+
+[ISC](LICENSE) Copyright (c) 2020, Karl Seguin

--- a/lib/auth.ex
+++ b/lib/auth.ex
@@ -1,77 +1,90 @@
 defmodule Monet.Auth do
-	@moduledoc """
-	Handles authenticating with the MonetDB server. Shouldn't be called directly.
-	Automatically invoked as part of the connection startup which is managed by the
-	connection pool (the Monet module).
-	"""
+  @moduledoc """
+  Handles authenticating with the MonetDB server. Shouldn't be called directly.
+  Automatically invoked as part of the connection startup which is managed by
+  the connection pool (the Monet module).
+  """
 
-	alias Monet.{Error, Writer, Reader}
+  alias Monet.{Error, Writer, Reader}
 
-	@doc """
-	The monetdbd process can either proxy or redirect us to the actual database
-	server (mserver5). Even when proxying, we're required to reconnect. In either
-	case, we want to limit how many times we'll attempt to do so.
+  @doc """
+  The monetdbd process can either proxy or redirect us to the actual database
+  server (mserver5). Even when proxying, we're required to reconnect. In either
+  case, we want to limit how many times we'll attempt to do so.
 
-	Currently, this is set to 10 (because that's what all the other drivers seem
-	to do.)
-	"""
-	def login(conn, opts, tries \\ 0)
+  Currently, this is set to 10 (because that's what all the other drivers seem
+  to do.)
+  """
+  def login(conn, opts, tries \\ 0)
 
-	def login(_conn, _opts, 10), do: {:error, Error.new(:driver, "too many proxy login iterations")}
+  def login(_conn, _opts, 10), do: {:error, Error.new(:driver, "too many proxy login iterations")}
 
-	def login(conn, opts, tries) do
-		with {:ok, challenge} <- Reader.message(conn),
-		     {:ok, salt, auth_types, hash_algo} <- parse_challenge(challenge),
-		     {:ok, auth_name, auth_type} <- parse_auth_types(auth_types),
-		     {:ok, hash_algo} <- parse_hash_algo(hash_algo)
-		do
-			password  = hash_algo |> :crypto.hash(opts[:password]) |> Base.encode16(case: :lower)
-			digest = auth_type |> :crypto.hash([password, salt]) |> Base.encode16(case: :lower)
-			Writer.send(conn, ["LIT:", opts[:username], ?:, auth_name, digest, ?:, "sql:", opts[:database], ?:])
-			verify(Reader.message(conn) , conn, opts, tries)
-		end
-	end
+  def login(conn, opts, tries) do
+    with {:ok, challenge} <- Reader.message(conn),
+         {:ok, salt, auth_types, hash_algo} <- parse_challenge(challenge),
+         {:ok, auth_name, auth_type} <- parse_auth_types(auth_types),
+         {:ok, hash_algo} <- parse_hash_algo(hash_algo) do
+      password = hash_algo |> :crypto.hash(opts[:password]) |> Base.encode16(case: :lower)
+      digest = auth_type |> :crypto.hash([password, salt]) |> Base.encode16(case: :lower)
 
-	# login was successfull
-	defp verify({:ok, ""}, conn, _opts, _tries), do: {:ok, conn}
+      Writer.send(conn, [
+        "LIT:",
+        opts[:username],
+        ?:,
+        auth_name,
+        digest,
+        ?:,
+        "sql:",
+        opts[:database],
+        ?:
+      ])
 
-	# monetdbd is going proxy our request to server, login again (and this time
-	# monetdbd will just be proxying the request)
-	defp verify({:ok, <<"^mapi:merovingian:", _::binary>>}, conn, opts, tries) do
-		login(conn, opts, tries + 1)
-	end
+      verify(Reader.message(conn), conn, opts, tries)
+    end
+  end
 
-	# montdbd is redirecting us to a specific server. connect to it
-	# TODO: This can be a list (\n separated, I guess we're supposed to try eac one?)
-	defp verify({:ok, <<"^mapi:", uri::binary>>}, _conn, _opts, _tries) do
-		uri = URI.parse(uri)
-		database = uri.path |> String.trim_leading("/") |> String.trim_trailing("\n")
-		{:redirect, [hostname: uri.host, port: uri.port, database: database]}
-	end
+  # login was successfull
+  defp verify({:ok, ""}, conn, _opts, _tries), do: {:ok, conn}
 
-	defp verify({:error, _} = err, _conn, _opts, _tries), do: err
+  # monetdbd is going proxy our request to server, login again (and this time
+  # monetdbd will just be proxying the request)
+  defp verify({:ok, <<"^mapi:merovingian:", _::binary>>}, conn, opts, tries) do
+    login(conn, opts, tries + 1)
+  end
 
-	defp parse_challenge(challenge) do
-		case String.split(challenge, ":") do
-			[salt, _, "9", auth_types, _endian, hash_algo, ""] -> {:ok, salt, auth_types, hash_algo}
-			_ -> {:error, Error.new(:driver, "unsupported challenge response", challenge)}
-		end
-	end
+  # montdbd is redirecting us to a specific server. connect to it
+  # TODO: This can be a list (\n separated, I guess we're supposed to try eac
+  # one?)
+  defp verify({:ok, <<"^mapi:", uri::binary>>}, _conn, _opts, _tries) do
+    uri = URI.parse(uri)
+    database = uri.path |> String.trim_leading("/") |> String.trim_trailing("\n")
+    {:redirect, [hostname: uri.host, port: uri.port, database: database]}
+  end
 
-	defp parse_auth_types(auth_types) do
-		auth_types = String.split(auth_types, ",")
-		cond do
-			"SHA512" in auth_types -> {:ok, "{SHA512}", :sha512}
-			"SHA256" in auth_types -> {:ok, "{SHA256}", :sha256}
-			"SHA224" in auth_types -> {:ok, "{SHA224}", :sha224}
-			"RIPEMD160" in auth_types -> {:ok, "{RIPEMD160}", :ripemd160}
-			true -> {:error, Error.new(:driver, "unsupported auth_types", auth_types)}
-		end
-	end
+  defp verify({:error, _} = err, _conn, _opts, _tries), do: err
 
-	defp parse_hash_algo("SHA512"), do: {:ok, :sha512}
-	defp parse_hash_algo("SHA256"), do: {:ok, :sha256}
-	defp parse_hash_algo("SHA384"), do: {:ok, :sha384}
-	defp parse_hash_algo("SHA224"), do: {:ok, :sha224}
-	defp parse_hash_algo(unknown), do: {:error, Error.new(:driver, "unsupport pwhash", unknown)}
+  defp parse_challenge(challenge) do
+    case String.split(challenge, ":") do
+      [salt, _, "9", auth_types, _endian, hash_algo, ""] -> {:ok, salt, auth_types, hash_algo}
+      _ -> {:error, Error.new(:driver, "unsupported challenge response", challenge)}
+    end
+  end
+
+  defp parse_auth_types(auth_types) do
+    auth_types = String.split(auth_types, ",")
+
+    cond do
+      "SHA512" in auth_types -> {:ok, "{SHA512}", :sha512}
+      "SHA256" in auth_types -> {:ok, "{SHA256}", :sha256}
+      "SHA224" in auth_types -> {:ok, "{SHA224}", :sha224}
+      "RIPEMD160" in auth_types -> {:ok, "{RIPEMD160}", :ripemd160}
+      true -> {:error, Error.new(:driver, "unsupported auth_types", auth_types)}
+    end
+  end
+
+  defp parse_hash_algo("SHA512"), do: {:ok, :sha512}
+  defp parse_hash_algo("SHA256"), do: {:ok, :sha256}
+  defp parse_hash_algo("SHA384"), do: {:ok, :sha384}
+  defp parse_hash_algo("SHA224"), do: {:ok, :sha224}
+  defp parse_hash_algo(unknown), do: {:error, Error.new(:driver, "unsupport pwhash", unknown)}
 end

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -1,280 +1,321 @@
 defmodule Monet.Connection do
-	@moduledoc """
-	Represents a connection (a socket) to the MonetDB Server.
+  @moduledoc """
+  Represents a connection (a socket) to the MonetDB Server.
 
-	Although this can be accessed directy (staring with conn/1), the intention is
-	for it to be accessed via the Monet module (which manages a pool of these
-	connections).
-	"""
+  Although this can be accessed directy (staring with conn/1), the intention is
+  for it to be accessed via the Monet module (which manages a pool of these
+  connections).
+  """
 
-	require Record
-	require Logger
+  require Record
+  require Logger
 
-	alias Monet.{Error, Prepared, Reader, Transaction, Writer}
+  alias Monet.{Error, Prepared, Reader, Transaction, Writer}
 
-	Record.defrecord(:connection,
-		socket: nil,
-		pool_name: nil,
-		read_timeout: 10_000,
-		send_timeout: 10_000,
-		connect_timeout: 10_000
-	)
+  Record.defrecord(:connection,
+    socket: nil,
+    pool_name: nil,
+    read_timeout: 10_000,
+    send_timeout: 10_000,
+    connect_timeout: 10_000
+  )
 
-	@doc """
-	A query with no arguments is executed as a simple query. A query with arguments
-	is executed as a prepare + exec + deallocate.
+  @doc """
+  A query with no arguments is executed as a simple query. A query with
+  arguments is executed as a prepare + exec + deallocate.
 
-	Query does not mutate the conn, but conn is returned nonetheless (along with the
-	result or error). The returned conn can be nil, which indicates that the connection
-	can no longer be used.
-	"""
-	def query(conn, sql, args \\ nil)
+  Query does not mutate the conn, but conn is returned nonetheless (along with
+  the result or error). The returned conn can be nil, which indicates that the
+  connection can no longer be used.
+  """
+  def query(conn, sql, args \\ nil)
 
-	def query(conn, sql, nil) do
-		with :ok <- Writer.query(conn, sql),
-		     {:ok, } = result <- Reader.result(conn)
-		do
-			{result, conn}
-		else
-			err -> error_result(err, conn)
-		end
-	end
+  def query(conn, sql, nil) do
+    with :ok <- Writer.query(conn, sql),
+         {:ok} = result <- Reader.result(conn) do
+      {result, conn}
+    else
+      err -> error_result(err, conn)
+    end
+  end
 
-	def query(conn, sql, args) do
-		with {:ok, prepared} <- Prepared.new(conn, sql),
-		     {:ok, result, c} <- Prepared.exec_and_close(prepared, args)
-		do
-			case c do
-				:ok -> {result, conn}
-				{:error, %{code: 7003}} ->
-					# Deallocating failed because the id wasn't valid. This easily happens
-					# (monetd automatically deallocates on a failed execution). It's no
-					# reason to remove the connection from the pool.
-					{result, conn}
-				_ ->
-					# We got an error deallocating which wasn't specifically about an invalid
-					# id. The connection is probably still good, but we don't want to leak
-					# prepared stamenents on the server. Safer to close this connection to
-					# force a cleanup.
-					{result, close(conn)}
-			end
-		else
-			err -> error_result(err, conn)
-		end
-	end
+  def query(conn, sql, args) do
+    with {:ok, prepared} <- Prepared.new(conn, sql),
+         {:ok, result, c} <- Prepared.exec_and_close(prepared, args) do
+      case c do
+        :ok ->
+          {result, conn}
 
-	@doc """
-	Runs `fun` in a transaction. Automaticaly starts and commits/rollsback the
-	transaction.
+        {:error, %{code: 7003}} ->
+          # Deallocating failed because the id wasn't valid. This easily
+          # happens (monetd automatically deallocates on a failed execution).
+          # It's no reason to remove the connection from the pool.
+          {result, conn}
 
-	When called through the pool (that is via `Monet.transaction/1`) the connection
-	is automatically closed (and thus the transaction rolledback) on an exception.
+        _ ->
+          # We got an error deallocating which wasn't specifically about an
+          # invalid id. The connection is probably still good, but we don't
+          # want to leak prepared stamenents on the server. Safer to close this
+          # connection to force a cleanup.
+          {result, close(conn)}
+      end
+    else
+      err -> error_result(err, conn)
+    end
+  end
 
-	If calling this directly, it is up to the caller to deal with exceptions.
-	"""
-	def transaction(conn, fun) do
-		tx = Transaction.new(conn)
-		with :ok <- Writer.query(conn, "start transaction"),
-		     {:ok, _} <- Reader.result(conn)
-		do
-			try do
-				fun_result = fun.(tx)
+  @doc """
+  Runs `fun` in a transaction. Automaticaly starts and commits/rollsback the
+  transaction.
 
-				# commit/rollback result
-				crb_result = case fun_result do
-					{:rollback, _} -> Transaction.rollback(tx)
-					_ -> Transaction.commit(tx)
-				end
+  When called through the pool (that is via `Monet.transaction/1`) the
+  connection is automatically closed (and thus the transaction rolledback) on
+  an exception.
 
-				case crb_result do
-					# If the commit/rollback failed, this is the result we'll return
-					# plus we might need to close the connection
-					{:error, err} ->
-						conn = if Error.closed?(err), do: nil, else: conn
-						{crb_result, conn}
-					:ok ->
-						# If the commit/rollback succeeded, we need to clean up the value
-						# returned by the supplied fun and we know we don't need to close
-						# the connection
-						value = case fun_result do
-							{:ok, _} = ok -> ok
-							{:error, _} = err -> err
-							{:rollback, _} = rlb -> rlb
-							{:commit, value} -> {:ok, value}
-							value -> {:ok, value}
-						end
-						{value, conn}
-				end
-			after
-				Transaction.close(tx) # deallocate any prepared statements
-			end
-		else
-			err -> error_result(err, conn)
-		end
-	end
+  If calling this directly, it is up to the caller to deal with exceptions.
+  """
+  def transaction(conn, fun) do
+    tx = Transaction.new(conn)
 
-	@doc """
-	Connects to the MonetDB server. See Monet.start_link/1 for available options
-	(although some of the options listed there such as `pool_size` are
-	specific to the Monet pool and not this individual connection).
-	"""
-	def connect(opts) do
-		connect_timeout = Keyword.get(opts, :connect_timeout, 10_000)
-		case :gen_tcp.connect(host(opts), port(opts), [packet: :raw, mode: :binary, active: false], connect_timeout) do
-			{:ok, socket} ->
-				with {:ok, conn} <- authenticate(socket, opts),
-			       {:ok, conn} <- configure(conn, opts)
-				do
-					{:ok, conn}
-				else
-					{:error, err} = error ->
-						:gen_tcp.close(socket)
-						Logger.error("Failed to initialie connection - #{inspect(err)}")
-						error
-				end
-			{:error, err} = error ->
-				Logger.error("Failed to connect to MonetDB on #{host(opts)}:#{port(opts)} - #{inspect(err)}")
-				error
-		end
-	end
+    with :ok <- Writer.query(conn, "start transaction"),
+         {:ok, _} <- Reader.result(conn) do
+      try do
+        fun_result = fun.(tx)
 
-	def close(conn) do
-		:gen_tcp.close(connection(conn, :socket))
-		nil
-	end
+        # commit/rollback result
+        crb_result =
+          case fun_result do
+            {:rollback, _} -> Transaction.rollback(tx)
+            _ -> Transaction.commit(tx)
+          end
 
-	# I don't think this logic is quite right. The idea is that we don't want
-	# to return a dead connection back into the pool.
-	defp error_result({:error, err} = result, conn) do
-		case Error.closed?(err) do
-			true -> {result, close(conn)}
-			false -> {result, conn}
-		end
-	end
+        case crb_result do
+          # If the commit/rollback failed, this is the result we'll return plus
+          # we might need to close the connection
+          {:error, err} ->
+            conn = if Error.closed?(err), do: nil, else: conn
+            {crb_result, conn}
 
-	defp error_result(result, conn) do
-		{result, conn}
-	end
+          :ok ->
+            # If the commit/rollback succeeded, we need to clean up the value
+            # returned by the supplied fun and we know we don't need to close
+            # the connection
+            value =
+              case fun_result do
+                {:ok, _} = ok -> ok
+                {:error, _} = err -> err
+                {:rollback, _} = rlb -> rlb
+                {:commit, value} -> {:ok, value}
+                value -> {:ok, value}
+              end
 
-	@doc """
-	In Elixir, every socket is assigned a "controlling" process. This is to control
-	the destination of incoming data when the socket is in active mode. We don't
-	use active mode (but we might leverage it in the future).
+            {value, conn}
+        end
+      after
+        # deallocate any prepared statements
+        Transaction.close(tx)
+      end
+    else
+      err -> error_result(err, conn)
+    end
+  end
 
-	Still, it appears that the socket is also tied to the lifetime of the
-	controlling process, so we do have to set this once in Monet.init_worker.
-	"""
-	def controlling_process(conn, pid) do
-		socket = connection(conn, :socket)
-		case :gen_tcp.controlling_process(socket, pid) do
-			:ok -> :ok
-			err -> :gen_tcp.close(socket); err
-		end
-	end
+  @doc """
+  Connects to the MonetDB server. See Monet.start_link/1 for available options
+  (although some of the options listed there such as `pool_size` are specific
+  to the Monet pool and not this individual connection).
+  """
+  def connect(opts) do
+    connect_timeout = Keyword.get(opts, :connect_timeout, 10_000)
 
-	defp authenticate(socket, opts) do
-		pool_name = Keyword.get(opts, :name, Monet)
-		send_timeout = Keyword.get(opts, :send_timeout, 10_000)
-		read_timeout = Keyword.get(opts, :read_timeout, 10_000)
-		connect_timeout = Keyword.get(opts, :connect_timeout, 10_000)
+    case :gen_tcp.connect(
+           host(opts),
+           port(opts),
+           [packet: :raw, mode: :binary, active: false],
+           connect_timeout
+         ) do
+      {:ok, socket} ->
+        with {:ok, conn} <- authenticate(socket, opts),
+             {:ok, conn} <- configure(conn, opts) do
+          {:ok, conn}
+        else
+          {:error, err} = error ->
+            :gen_tcp.close(socket)
+            Logger.error("Failed to initialie connection - #{inspect(err)}")
+            error
+        end
 
-		username = Keyword.get(opts, :username, "monetdb")
-		password = Keyword.get(opts, :password, "monetdb")
-		database = Keyword.get(opts, :database, "monetdb")
+      {:error, err} = error ->
+        Logger.error(
+          "Failed to connect to MonetDB on #{host(opts)}:#{port(opts)} - #{inspect(err)}"
+        )
 
-		conn = connection(
-			socket: socket,
-			pool_name: pool_name,
-			send_timeout: send_timeout,
-			read_timeout: read_timeout,
-			connect_timeout: connect_timeout
-		)
+        error
+    end
+  end
 
-		:inet.setopts(socket, send_timeout: Keyword.get(opts, :send_timeout, 10_000))
+  def close(conn) do
+    :gen_tcp.close(connection(conn, :socket))
+    nil
+  end
 
-		case Monet.Auth.login(conn, username: username, password: password, database: database) do
-			{:ok, _} = ok -> ok
-			{:error, _} = err -> err
-			{:redirect, redirect} ->
-				:gen_tcp.close(socket)
-				connect(Keyword.merge(opts, redirect))
-		end
-	end
+  # I don't think this logic is quite right. The idea is that we don't want to
+  # return a dead connection back into the pool.
+  defp error_result({:error, err} = result, conn) do
+    case Error.closed?(err) do
+      true -> {result, close(conn)}
+      false -> {result, conn}
+    end
+  end
 
-	# there are some commands we want to send on startup
-	defp configure(conn, opts) do
-		with {:ok, conn} <- set_time_zone(conn, opts),
-		     {:ok, conn} <- set_reply_size(conn),
-		     {:ok, conn} <- set_schema(conn, opts),
-		     {:ok, conn} <- set_role(conn, opts)
-		do
-			{:ok, conn}
-		end
-	end
+  defp error_result(result, conn) do
+    {result, conn}
+  end
 
-	defp set_time_zone(conn, opts) do
-		offset = case Keyword.get(opts, :time_zone_offset) do
-			nil -> "0"
-			n when is_integer(n) -> Integer.to_string(n)
-			err -> {:error, ":time_zone_offset offset must be nil or an integer, got: #{inspect(err)}"}
-		end
+  @doc """
+  In Elixir, every socket is assigned a "controlling" process. This is to
+  control the destination of incoming data when the socket is in active mode.
+  We don't use active mode (but we might leverage it in the future).
 
-		Writer.query(conn, "set time zone interval '#{offset}' minute;")
-		case Reader.message(conn) do
-			{:ok, <<"&3 ", _::binary>>} -> {:ok, conn}
-			{:ok, invalid} -> {:error, "Unexpected reply from set time zone: #{invalid}"}
-			err -> err
-		end
-	end
+  Still, it appears that the socket is also tied to the lifetime of the
+  controlling process, so we do have to set this once in Monet.init_worker.
+  """
+  def controlling_process(conn, pid) do
+    socket = connection(conn, :socket)
 
-	# I don't know what the default is, but every other drivers sets this so that
-	# queries don't return a limited result.
-	defp set_reply_size(conn) do
-		Writer.command(conn, "reply_size -1")
-		case Reader.message(conn) do
-			{:ok, ""} -> {:ok, conn}
-			{:ok, invalid} -> {:error, "Unexpected reply from reply_size command: #{invalid}"}
-			err -> err
-		end
-	end
+    case :gen_tcp.controlling_process(socket, pid) do
+      :ok ->
+        :ok
 
-	defp set_schema(conn, opts) do
-		case Keyword.get(opts, :schema) do
-			nil -> {:ok, conn}
-			schema ->
-				Writer.query(conn, "set schema #{schema}")
-				case Reader.message(conn) do
-					{:ok, <<"&3 ", _::binary>>} -> {:ok, conn}
-					{:ok, invalid} -> {:error, "Unexpected reply from set schema: #{invalid}"}
-					err -> err
-				end
-		end
-	end
+      err ->
+        :gen_tcp.close(socket)
+        err
+    end
+  end
 
-	defp set_role(conn, opts) do
-		case Keyword.get(opts, :role) do
-			nil -> {:ok, conn}
-			role ->
-				Writer.query(conn, "set role #{role}")
-				case Reader.message(conn) do
-					{:ok, <<"&3 ", _::binary>>} -> {:ok, conn}
-					{:ok, invalid} -> {:error, "Unexpected reply from set role: #{invalid}"}
-					err -> err
-				end
-		end
-	end
+  defp authenticate(socket, opts) do
+    pool_name = Keyword.get(opts, :name, Monet)
+    send_timeout = Keyword.get(opts, :send_timeout, 10_000)
+    read_timeout = Keyword.get(opts, :read_timeout, 10_000)
+    connect_timeout = Keyword.get(opts, :connect_timeout, 10_000)
 
-	# only extracted so that we can reuse the logic when logging a connection error
-	defp port(opts), do: Keyword.get(opts, :port, 50_000)
-	defp host(opts) do
-		case Keyword.get(opts, :host) do
-			nil -> '127.0.0.1'
-			host -> String.to_charlist(host)
-		end
-	end
+    username = Keyword.get(opts, :username, "monetdb")
+    password = Keyword.get(opts, :password, "monetdb")
+    database = Keyword.get(opts, :database, "monetdb")
 
-	@doc """
-	Get the name of the pool this connection belongs tos
-	"""
-	def pool_name(conn), do: connection(conn, :pool_name)
+    conn =
+      connection(
+        socket: socket,
+        pool_name: pool_name,
+        send_timeout: send_timeout,
+        read_timeout: read_timeout,
+        connect_timeout: connect_timeout
+      )
+
+    :inet.setopts(socket, send_timeout: Keyword.get(opts, :send_timeout, 10_000))
+
+    case Monet.Auth.login(conn, username: username, password: password, database: database) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _} = err ->
+        err
+
+      {:redirect, redirect} ->
+        :gen_tcp.close(socket)
+        connect(Keyword.merge(opts, redirect))
+    end
+  end
+
+  # there are some commands we want to send on startup
+  defp configure(conn, opts) do
+    with {:ok, conn} <- set_time_zone(conn, opts),
+         {:ok, conn} <- set_reply_size(conn),
+         {:ok, conn} <- set_schema(conn, opts),
+         {:ok, conn} <- set_role(conn, opts) do
+      {:ok, conn}
+    end
+  end
+
+  defp set_time_zone(conn, opts) do
+    offset =
+      case Keyword.get(opts, :time_zone_offset) do
+        nil ->
+          "0"
+
+        n when is_integer(n) ->
+          Integer.to_string(n)
+
+        err ->
+          {:error, ":time_zone_offset offset must be nil or an integer, got: #{inspect(err)}"}
+      end
+
+    Writer.query(conn, "set time zone interval '#{offset}' minute;")
+
+    case Reader.message(conn) do
+      {:ok, <<"&3 ", _::binary>>} -> {:ok, conn}
+      {:ok, invalid} -> {:error, "Unexpected reply from set time zone: #{invalid}"}
+      err -> err
+    end
+  end
+
+  # I don't know what the default is, but every other drivers sets this so that
+  # queries don't return a limited result.
+  defp set_reply_size(conn) do
+    Writer.command(conn, "reply_size -1")
+
+    case Reader.message(conn) do
+      {:ok, ""} -> {:ok, conn}
+      {:ok, invalid} -> {:error, "Unexpected reply from reply_size command: #{invalid}"}
+      err -> err
+    end
+  end
+
+  defp set_schema(conn, opts) do
+    case Keyword.get(opts, :schema) do
+      nil ->
+        {:ok, conn}
+
+      schema ->
+        Writer.query(conn, "set schema #{schema}")
+
+        case Reader.message(conn) do
+          {:ok, <<"&3 ", _::binary>>} -> {:ok, conn}
+          {:ok, invalid} -> {:error, "Unexpected reply from set schema: #{invalid}"}
+          err -> err
+        end
+    end
+  end
+
+  defp set_role(conn, opts) do
+    case Keyword.get(opts, :role) do
+      nil ->
+        {:ok, conn}
+
+      role ->
+        Writer.query(conn, "set role #{role}")
+
+        case Reader.message(conn) do
+          {:ok, <<"&3 ", _::binary>>} -> {:ok, conn}
+          {:ok, invalid} -> {:error, "Unexpected reply from set role: #{invalid}"}
+          err -> err
+        end
+    end
+  end
+
+  # only extracted so that we can reuse the logic when logging a connection
+  # error
+  defp port(opts), do: Keyword.get(opts, :port, 50_000)
+
+  defp host(opts) do
+    case Keyword.get(opts, :host) do
+      nil -> '127.0.0.1'
+      host -> String.to_charlist(host)
+    end
+  end
+
+  @doc """
+  Get the name of the pool this connection belongs tos
+  """
+  def pool_name(conn), do: connection(conn, :pool_name)
 end

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -1,63 +1,66 @@
 defmodule Monet.Error do
-	@moduledoc """
-	Represents an error.
+  @moduledoc """
+  Represents an error.
 
-	The `source` field is `:monetd` when the error was returned by the MonetDB server.
-	In such cases the `code` field should be the integer code returned (though it
-	could be `nil` in the unlikely case that the error couldn't be parsed properly).
+   The `source` field is `:monetd` when the error was returned by the MonetDB
+   server.  In such cases the `code` field should be the integer code returned
+   (though it could be `nil` in the unlikely case that the error couldn't be
+   parsed properly).
 
-	The `source` field is `client` when Monet.row, Monet.row!, Monet.map,
-	Monet.map!, Monet.scalar or Monet.scalar! are called on a result with more
-	rows or columns than is expected (e.g., calling Monet.scalar on a result that
-	has more than 1 row or more than 1 column).Monet
+   The `source` field is `client` when Monet.row, Monet.row!, Monet.map,
+   Monet.map!, Monet.scalar or Monet.scalar! are called on a result with more
+   rows or columns than is expected (e.g., calling Monet.scalar on a result that
+   has more than 1 row or more than 1 column).Monet
 
-	Otherwise the `source` field can be either `:network` or `:driver` to indicate a
-	tcp-level error or an error arising from this library. In both cases, `code`
-	will always be nil.
+   Otherwise the `source` field can be either `:network` or `:driver` to
+   indicate a tcp-level error or an error arising from this library. In both
+   cases, `code` will always be nil.
 
-	The `message` field contains a human readable description of the problem. It is
-	always present. It's usually a string, except when `source` is `:tcp` it will
-	be an atom.
+   The `message` field contains a human readable description of the problem. It
+   is always present. It's usually a string, except when `source` is `:tcp` it
+   will be an atom.
 
-	The `details` field can contain anything, including `nil`. This is generally
-	set by `Monet.Reader` on a parsing error to provide some context about the
-	data which could not be parsed.
-	"""
+   The `details` field can contain anything, including `nil`. This is generally
+   set by `Monet.Reader` on a parsing error to provide some context about the
+   data which could not be parsed.
+  """
 
-	alias __MODULE__
+  alias __MODULE__
 
-	defexception [
-		:source,
-		:message,
-		:details,
-		:code,
-	]
+  defexception [
+    :source,
+    :message,
+    :details,
+    :code
+  ]
 
-	@doc """
-	Turns an Monet.Error into a binary for display
-	"""
-	def message(e) do
-		:erlang.iolist_to_binary([
-			Atom.to_string(e.source), ?\s,
-			to_string(e.message),  # can be an atom
-			details(e.details)
-		])
-	end
+  @doc """
+   Turns an `Monet.Error` into a binary for display.
+  """
+  def message(e) do
+    :erlang.iolist_to_binary([
+      Atom.to_string(e.source),
+      ?\s,
+      # can be an atom
+      to_string(e.message),
+      details(e.details)
+    ])
+  end
 
-	@doc false
-	def new(source, message) do
-		%Error{source: source, message: message, details: nil}
-	end
+  @doc false
+  def new(source, message) do
+    %Error{source: source, message: message, details: nil}
+  end
 
-	@doc false
-	def new(source, message, <<details::binary>>) do
-		%Error{source: source, message: message, details: details}
-	end
+  @doc false
+  def new(source, message, <<details::binary>>) do
+    %Error{source: source, message: message, details: details}
+  end
 
-	@doc false
-	def closed?(%{source: :network}), do: true
-	def closed?(_), do: false
+  @doc false
+  def closed?(%{source: :network}), do: true
+  def closed?(_), do: false
 
-	defp details(nil), do: []
-	defp details(details), do: ["\n\n" | inspect(details)]
+  defp details(nil), do: []
+  defp details(details), do: ["\n\n" | inspect(details)]
 end

--- a/lib/monet.ex
+++ b/lib/monet.ex
@@ -1,405 +1,443 @@
 defmodule Monet do
-	@moduledoc """
-	Main interface for interacting with a MonetDB server. Implemented as a pool
-	of Monet.Connection. Commands such as query/1 check out a Connection from
-	the pool, call query/1 on it, and then check it back in.
+  @moduledoc """
+  Main interface for interacting with a MonetDB server. Implemented as a pool
+  of `Monet.Connection`. Commands such as `query/1` check out a Connection
+  from the pool, call `query/1` on it, and then check it back in.
 
-	The pool has a simple backoff implementation in the case of failed connections.
-	The maximum sleep time before trying to reconnect is 4 seconds.
-	"""
+  The pool has a simple backoff implementation in the case of failed
+  connections. The maximum sleep time before trying to reconnect is 4 seconds.
+  """
 
-	require Record
+  require Record
 
-	@behaviour NimblePool
+  @behaviour NimblePool
 
-	Record.defrecord(:pool,
-		config: nil,
-		failures: 0
-	)
+  Record.defrecord(:pool,
+    config: nil,
+    failures: 0
+  )
 
-	alias Monet.{Connection, Result, Transaction}
+  alias Monet.{Connection, Result, Transaction}
 
-	@doc """
-	Returns a supervisor child specification for a pool of Monet.Connections.
-	"""
-	def child_spec(opts) do
-		%{
-			id: opts[:name] || __MODULE__,
-			start: {Monet, :start_link, [opts]}
-		}
-	end
+  @doc """
+  Returns a supervisor child specification for a pool of `Monet.Connections`.
+  """
+  def child_spec(opts) do
+    %{
+      id: opts[:name] || __MODULE__,
+      start: {Monet, :start_link, [opts]}
+    }
+  end
 
-	@doc """
-	Starts the pool and establishes the specified number of connections
+  @doc """
+  Starts the pool and establishes the specified number of connections
 
-	## Options
-	* `:connect_timeout` - Timeout, in milliseconds, to conn10_000
-	* `:database` - Database to conenct to (default: "monetdb")
-	* `:host` - Hostname or IP of the server to connect to (default:"127.0.0.1")
-	* `:name` - The process name of the pool (default: Monet)
-	* `:password` - Password to use (default: "monetdb")
-	* `:pool_size` - Size of the conncetion pool (default: 10)
-	* `:port` - Port of the server to connect to (default: 50_000)
-	* `:schema` - The schema to use (defautls to not sending a 'set schema' command (and thus defaults to the user's defautl schema))
-	* `:role` - The role to use (defautls to not sending a 'set role' command (and thus defaults to the user's defautl role))
-	* `:read_timeout` - Timeout, in milliseconds, for individual tcp recv operations (default: 10_000)
-	* `:send_timeout` - Timeout, in milliseconds, for individual tcp send operatins (default: 10_000)
-	* `:username` - Username to use (default: "monetdb")
+  ## Options
 
-	If a `:name` is given, that value must be provided as the first parameter to
-	other functions in this module.
-	"""
-	def start_link(opts) do
-		{name, opts} = case Keyword.get(opts, :name) do
-			nil -> {__MODULE__, Keyword.put(opts, :name, __MODULE__)}
-			name -> {name, opts}
-		end
-		{pool_size, opts} = Keyword.pop(opts, :pool_size, 10)
-		p = pool(failures: 0, config: opts)
-		child = {NimblePool, worker: {Monet, p}, pool_size: pool_size, name: name}
-		Supervisor.start_link([child], strategy: :one_for_one)
-	end
+    * `:connect_timeout` - Timeout, in milliseconds, to conn10_000
+    * `:database` - Database to conenct to (default: "monetdb")
+    * `:host` - Hostname or IP of the server to connect to (default:"127.0.0.1")
+    * `:name` - The process name of the pool (default: Monet)
+    * `:password` - Password to use (default: "monetdb")
+    * `:pool_size` - Size of the conncetion pool (default: 10)
+    * `:port` - Port of the server to connect to (default: 50_000)
+    * `:schema` - The schema to use (defautls to not sending a 'set schema'
+      command (and thus defaults to the user's defautl schema))
+    * `:role` - The role to use (defautls to not sending a 'set role' command
+      (and thus defaults to the user's defautl role))
+    * `:read_timeout` - Timeout, in milliseconds, for individual tcp recv operations (default: 10_000)
+    * `:send_timeout` - Timeout, in milliseconds, for individual tcp send operatins (default: 10_000)
+    * `:username` - Username to use (default: "monetdb")
 
-	@doc """
-	Executes a query. Returns {:ok, %Monet.Result{}} or {:error, %Monet.Error{}}
-	If no pool name is given, then the default name, Monet, is used.
-	If no arguments are given, then a simple query is executed, otherwise, the
-	query is prepared + executed + deallocated.
-	"""
-	def query(sql), do: query(__MODULE__, sql, nil)
-	def query(pool, sql) when is_atom(pool) or is_pid(pool), do: query(pool, sql, nil)
+  If a `:name` is given, that value must be provided as the first parameter to
+  other functions in this module.
+  """
+  def start_link(opts) do
+    {name, opts} =
+      case Keyword.get(opts, :name) do
+        nil -> {__MODULE__, Keyword.put(opts, :name, __MODULE__)}
+        name -> {name, opts}
+      end
 
-	def query(tx, sql) when elem(tx, 0) == :transaction, do: query(tx, sql, nil)
-	def query(sql, args), do: query(__MODULE__, sql, args)
+    {pool_size, opts} = Keyword.pop(opts, :pool_size, 10)
+    p = pool(failures: 0, config: opts)
+    child = {NimblePool, worker: {Monet, p}, pool_size: pool_size, name: name}
+    Supervisor.start_link([child], strategy: :one_for_one)
+  end
 
-	def query(tx, sql, args) when elem(tx, 0) == :transaction, do: Transaction.query(tx, sql, args)
-	def query(pool, sql, args) do
-		NimblePool.checkout!(pool, :checkout, fn _from, conn ->
-			Connection.query(conn, sql, args)
-		end)
-	end
+  @doc """
+  Executes a query. Returns `{:ok, %Monet.Result{}}` or `{:error, %Monet.Error{}}`.
 
-	@doc """
-	Same as query but returns a %Monet.Result{} or raises a %Monet.Error{}.
-	"""
-	def query!(sql), do: query!(__MODULE__, sql, nil)
-	def query!(pool, sql) when is_atom(pool) or is_pid(pool), do: query!(pool, sql, nil)
+  If no pool name is given, then the default name, `Monet`, is used.
 
-	def query!(tx, sql) when elem(tx, 0) == :transaction, do: query!(tx, sql, nil)
-	def query!(sql, args), do: query!(__MODULE__, sql, args)
+  If no arguments are given, then a simple query is executed, otherwise, the
+  query is prepared + executed + deallocated.
+  """
+  def query(sql), do: query(__MODULE__, sql, nil)
+  def query(pool, sql) when is_atom(pool) or is_pid(pool), do: query(pool, sql, nil)
 
-	def query!(tx, sql, args) when elem(tx, 0) == :transaction do
-		case Transaction.query(tx, sql, args) do
-			{:ok, result} -> result
-			{:error, err} -> raise err
-		end
-	end
-	def query!(pool, sql, args) do
-		case query(pool, sql, args) do
-			{:ok, result} -> result
-			{:error, err} -> raise err
-		end
-	end
+  def query(tx, sql) when elem(tx, 0) == :transaction, do: query(tx, sql, nil)
+  def query(sql, args), do: query(__MODULE__, sql, args)
 
-	@doc """
-	Checkouts a connection and runs `fun` within a transaction.
+  def query(tx, sql, args) when elem(tx, 0) == :transaction, do: Transaction.query(tx, sql, args)
 
-	If `fun` returns `{:rollback, res}`, the transaction is rolled back and
-	`{:error, res}` is returned. Alternatively, `Monet.rollback/2` can be used to
-	the same effect.
+  def query(pool, sql, args) do
+    NimblePool.checkout!(pool, :checkout, fn _from, conn ->
+      Connection.query(conn, sql, args)
+    end)
+  end
 
-	NOTE: The above means that, unlike other functions which only return
-	`{:ok, %Monet.Result{}}` or `{:error, %Monet.Error{}}`, this function can
-	also return `{:error, term}` where `term` is any value passed to `Monet.rollback/2`)
-	or specified via `{:rollback, value}`.
+  @doc """
+  Same as query but returns a `%Monet.Result{}` or raises a `%Monet.Error{}`.
+  """
+  def query!(sql), do: query!(__MODULE__, sql, nil)
+  def query!(pool, sql) when is_atom(pool) or is_pid(pool), do: query!(pool, sql, nil)
 
-	Any other value returned by `fun` will result in the transaction being committed:
+  def query!(tx, sql) when elem(tx, 0) == :transaction, do: query!(tx, sql, nil)
+  def query!(sql, args), do: query!(__MODULE__, sql, args)
 
-			Monet.transaction(fn tx ->
-				Monet.query(tx, "....")
-				Monet.query(tx, "....")
-			end)
+  def query!(tx, sql, args) when elem(tx, 0) == :transaction do
+    case Transaction.query(tx, sql, args) do
+      {:ok, result} -> result
+      {:error, err} -> raise err
+    end
+  end
 
-	To be more explicit, `fun` can return `{:commit, result}` in which case the
-	transaction will be commited and `{:ok, result}` will be returned.
-	"""
-	def transaction(pool \\ __MODULE__, fun) do
-		NimblePool.checkout!(pool, :checkout, fn _from, conn ->
-			Connection.transaction(conn, fun)
-		end)
-	end
+  def query!(pool, sql, args) do
+    case query(pool, sql, args) do
+      {:ok, result} -> result
+      {:error, err} -> raise err
+    end
+  end
 
-	@doc """
-	Same as query but returns a %Monet.Result{}, raises a %Monet.Error{} or raises
-	whatever custom rollback value you provide.
-	"""
-	def transaction!(pool \\ __MODULE__, sql) do
-		case transaction(pool, sql) do
-			{:ok, result} -> result
-			{:error, err} -> raise err
-		end
-	end
+  @doc """
+  Checkouts a connection and runs `fun` within a transaction.
 
-	@doc """
-	Commits the transaction. This can either be called implicitly based on the
-	return value of your transaction `fun`:
+  If `fun` returns `{:rollback, res}`, the transaction is rolled back and
+  `{:error, res}` is returned. Alternatively, `Monet.rollback/2` can be used to
+  the same effect.
 
-			Monet.transaction!(fn tx ->
-				....
-				{:commit, return_value} # or simply {:ok, return_value}
-			end)
+  NOTE: The above means that, unlike other functions which only return
+  `{:ok, %Monet.Result{}}` or `{:error, %Monet.Error{}}`, this function can
+  also return `{:error, term}` where `term` is any value passed to `Monet.rollback/2`)
+  or specified via `{:rollback, value}`.
 
-	 or explicitly:
+  Any other value returned by `fun` will result in the transaction being committed:
 
-			Monet.transaction!(fn tx ->
-				....
-				Monet.commit(tx, return_value)
-			end)
-	"""
-	def commit(tx, {:ok, result}), do: commit(tx, result)
-	def commit(tx, {:commit, result}), do: commit(tx, result)
-	def commit(tx, result) do
-		with :ok <- Monet.Transaction.commit(tx) do
-			{:ok, result}
-		end
-	end
+  ## Examples
 
-	@doc """
-	Rollsback the transaction. This can either be called implicitly based on the
-	return value of your transaction `fun`:
+      Monet.transaction(fn tx ->
+        Monet.query(tx, "....")
+        Monet.query(tx, "....")
+      end)
 
-			Monet.transaction!(fn tx ->
-				....
-				{:rollback, return_value}
-			end)
+  To be more explicit, `fun` can return `{:commit, result}` in which case the
+  transaction will be commited and `{:ok, result}` will be returned.
+  """
+  def transaction(pool \\ __MODULE__, fun) do
+    NimblePool.checkout!(pool, :checkout, fn _from, conn ->
+      Connection.transaction(conn, fun)
+    end)
+  end
 
-	 or explicitly:
+  @doc """
+  Same as query but returns a %Monet.Result{}, raises a %Monet.Error{} or raises
+  whatever custom rollback value you provide.
+  """
+  def transaction!(pool \\ __MODULE__, sql) do
+    case transaction(pool, sql) do
+      {:ok, result} -> result
+      {:error, err} -> raise err
+    end
+  end
 
-			Monet.transaction!(fn tx ->
-				....
-				Monet.rollback(tx, return_value)
-			end)
-	"""
-	def rollback(tx, result) do
-		with :ok <- Monet.Transaction.rollback(tx) do
-			{:error, result}
-		end
-	end
+  @doc """
+  Commits the transaction. This can either be called implicitly based on the
+  return value of your transaction `fun`:
 
-	@doc """
-	Creates a prepared statement for use in a transaction. The statements are
-	automatically cleaned up at the end of the transaction.
+  ## Examples
 
-	Use with care. MonetDB automatically deallocates prepared statements on
-	execution error. If a query using a prepared statement fails in your transaction
-	you should probably end the transaction.
+       Monet.transaction!(fn tx ->
+       ....
+         {:commit, return_value} # or simply {:ok, return_value}
+       end)
 
-			Monet.transaction(fn tx ->
-				Monet.prepare(tx, :test_insert, "insert into test (id) values (?)")
-				with {:ok, r1} <- Monet.query(tx, :test_insert, [1]),
-				     {:ok, r2} <- Monet.query(tx, :test_insert, [2])
-				do
-					{:ok, [r1, r2]}
-				else
-					err -> {:rollback, err}
-				end
-			end)
-	"""
-	def prepare(tx, name, sql) when elem(tx, 0) == :transaction do
-		Transaction.prepare(tx, name, sql)
-	end
+  or explicitly:
 
-	def prepare!(tx, name, sql) when elem(tx, 0) == :transaction do
-		case prepare(tx, name, sql) do
-			:ok -> :ok
-			{:error, err} -> raise err
-		end
-	end
+       Monet.transaction!(fn tx ->
+       ....
+         Monet.commit(tx, return_value)
+       end)
 
-	@doc """
-	By default, the `Monet.Result` returned from a select will enumerate a list of
-	lists (via the Enumerable protocol or Jason.encode).
+  """
+  def commit(tx, {:ok, result}), do: commit(tx, result)
+  def commit(tx, {:commit, result}), do: commit(tx, result)
 
-	The behavior can be changed to enumerate or encode to a list of maps:
+  def commit(tx, result) do
+    with :ok <- Monet.Transaction.commit(tx) do
+      {:ok, result}
+    end
+  end
 
-			"select id, name from saiyans"
-			|> Monet.query!()
-			|> Monet.as_map()
-			|> Jason.encode()  # or Enum.reduce/map/...
+  @doc """
+  Rollsback the transaction. This can either be called implicitly based on the
+  return value of your transaction `fun`:
 
-	Note that calling `as_map` does not change the `rows` field of the result. It
-	merely configures how the enumeration will operate. So, to get a list of all
-	maps with columns as atoms, one would do:
+  ## Examples
 
-			"select id, name from saiyans"
-			|> Monet.query!()
-			|> Monet.as_map(columns: :atoms)
-			|> Enum.list()
+      Monet.transaction!(fn tx ->
+        ....
+        {:rollback, return_value}
+      end)
 
-	`as_map` works on any value returned by `query` and `query!`. In the case of an
-	error, the error is simply returned. As such, a safer usage would be:
+  or explicitly:
 
-		case Monet.as_map(Monet.query("select id, name from saiyans")) do
-			{:ok, result} -> ...
-			{:error, err} -> ...
-		end
-	"""
-	def as_map(value, opts \\ [])
-	def as_map({:ok, result}, opts), do: Result.as_map(result, opts)
-	def as_map(%Result{} = result, opts), do: as_map({:ok, result}, opts)
-	def as_map(error, _opts), do: error
+      Monet.transaction!(fn tx ->
+        ....
+        Monet.rollback(tx, return_value)
+      end)
 
-	# can't fail, but prove a ! variant for consistency
-	def rows({:ok, result}), do: {:ok, result.rows}
-	def rows(%Result{} = result), do: {:ok, result.rows}
-	def rows(error), do: error
-	def rows!({:ok, result}), do: result.rows
-	def rows!(%Result{} = result), do: result.rows
-	def rows!({:error, err}), do: raise err
+  """
+  def rollback(tx, result) do
+    with :ok <- Monet.Transaction.rollback(tx) do
+      {:error, result}
+    end
+  end
 
-	def row({:ok, result}) do
-		case result.rows do
-			[] -> {:ok, nil}
-			[row] -> {:ok, row}
-			_ -> {:error, Monet.Error.new(:client, "row called but multiple rows returned")}
-		end
-	end
-	def row(%Result{} = result), do: row({:ok, result})
-	def row(error), do: error
-	def row!({:ok, _} = result), do: unwrap!(row(result))
-	def row!(%Result{} = result), do: unwrap!(row({:ok, result}))
-	def row!({:error, err}), do: raise err
+  @doc """
+  Creates a prepared statement for use in a transaction. The statements are
+  automatically cleaned up at the end of the transaction.
 
-	def maps(input, opts \\ [])
-	def maps({:ok, result}, opts) do
-		{:ok, result |> as_map(opts) |> Enum.to_list()}
-	end
-	def maps(%Result{} = result, opts), do: maps({:ok, result}, opts)
-	def maps(error, _opts), do: error
+  Use with care. MonetDB automatically deallocates prepared statements on
+  execution error. If a query using a prepared statement fails in your
+  transaction you should probably end the transaction.
 
-	def maps!(input, opts \\ [])
-	def maps!({:ok, _} = result, opts), do: result |> as_map(opts) |> Enum.to_list()
-	def maps!(%Result{} = result, opts), do: maps!({:ok, result}, opts)
-	def maps!({:error, err}, _opts), do: raise err
+  ## Examples
 
-	def map(input, opts \\ [])
-	def map({:ok, result}, opts) do
-		case result.rows do
-			[] -> {:ok, nil}
-			[row] ->
-				row = result.columns
-				|> columns_for_map(opts)
-				|> Enum.zip(row)
-				|> Map.new()
-				{:ok, row}
-			_ -> {:error, Monet.Error.new(:client, "map called but multiple rows returned")}
-		end
-	end
-	def map(%Result{} = result, opts), do: map({:ok, result}, opts)
-	def map(error, _opts), do: error
+      Monet.transaction(fn tx ->
+        Monet.prepare(tx, :test_insert, "insert into test (id) values (?)")
+        with {:ok, r1} <- Monet.query(tx, :test_insert, [1]),
+             {:ok, r2} <- Monet.query(tx, :test_insert, [2])
+        do
+          {:ok, [r1, r2]}
+        else
+          err -> {:rollback, err}
+        end
+      end)
 
-	def map!(input, opts \\ [])
-	def map!({:ok, _} = result, opts), do: unwrap!(map(result, opts))
-	def map!(%Result{} = result, opts), do: unwrap!(map({:ok, result}, opts))
-	def map!({:error, err}, _opts), do: raise err
+  """
+  def prepare(tx, name, sql) when elem(tx, 0) == :transaction do
+    Transaction.prepare(tx, name, sql)
+  end
 
-	def scalar({:ok, result}) do
-		case result.rows do
-			[] -> {:ok, nil}
-			[[value]] -> {:ok, value}
-			[_, _ | _] -> {:error, Monet.Error.new(:client, "scalar called but multiple rows returned")}
-			_ -> {:error, Monet.Error.new(:client, "scalar called but multiple columns returned")}
-		end
-	end
-	def scalar(%Result{} = result), do: scalar({:ok, result})
-	def scalar(error), do: error
-	def scalar!({:ok, _} = result), do: unwrap!(scalar(result))
-	def scalar!(%Result{} = result), do: unwrap!(scalar({:ok, result}))
-	def scalar!({:error, err}), do: raise err
+  def prepare!(tx, name, sql) when elem(tx, 0) == :transaction do
+    case prepare(tx, name, sql) do
+      :ok -> :ok
+      {:error, err} -> raise err
+    end
+  end
 
-	defp unwrap!({:ok, result}), do: result
-	defp unwrap!({:error, err}), do: raise err
+  @doc """
+  By default, the `Monet.Result` returned from a select will enumerate a list
+  of lists (via the Enumerable protocol or Jason.encode).
 
-	defp columns_for_map(columns, opts) do
-		case opts[:columns] do
-			:atoms -> Enum.map(columns, &String.to_atom/1)
-			_ -> columns
-		end
-	end
+  The behavior can be changed to enumerate or encode to a list of maps:
 
-	@impl NimblePool
-	def init_pool(state) do
-		name = Keyword.fetch!(pool(state, :config), :name)
-		# table is used by the transaction prepared statement cache
-		:ets.new(name, [:set, :public, :named_table])
-		{:ok, state}
-	end
+      "select id, name from saiyans"
+      |> Monet.query!()
+      |> Monet.as_map()
+      |> Jason.encode()  # or Enum.reduce/map/...
 
-	@impl NimblePool
-	def init_worker(state) do
-		with {:ok, conn} <- Connection.connect(pool(state, :config)),
-				 :ok <- Connection.controlling_process(conn, self())
-		do
-			{:ok, conn, reset(state)}
-		else
-			_ -> {:ok, nil, backoff(state)}
-		end
+  Note that calling `as_map` does not change the `rows` field of the result. It
+  merely configures how the enumeration will operate. So, to get a list of all
+  maps with columns as atoms, one would do:
 
-	end
+      "select id, name from saiyans"
+      |> Monet.query!()
+      |> Monet.as_map(columns: :atoms)
+      |> Enum.list()
 
-	@impl NimblePool
-	def handle_checkout(:checkout, _, nil, state)  do
-		failures = pool(state, :failures)
-		# micro-opt, bu thtere's no point in increasing this value any more since
-		# we've reached our max backoff
-		state = case failures > 10 do
-			true -> state
-			false -> pool(state, failures: failures + 1)
-		end
-		{:remove, :down, state}
-	end
+  `as_map` works on any value returned by `query` and `query!`. In the case of
+  an error, the error is simply returned. As such, a safer usage would be:
 
-	def handle_checkout(:checkout, {_pid, _}, conn, state) do
-		{:ok, conn, conn, state}
-	end
+      case Monet.as_map(Monet.query("select id, name from saiyans")) do
+        {:ok, result} -> ...
+        {:error, err} -> ...
+      end
 
-	@impl NimblePool
-	def handle_checkin(nil, _from, _conn, pool_state) do
-		{:remove, :closed, pool_state}
-	end
+  """
+  def as_map(value, opts \\ [])
+  def as_map({:ok, result}, opts), do: Result.as_map(result, opts)
+  def as_map(%Result{} = result, opts), do: as_map({:ok, result}, opts)
+  def as_map(error, _opts), do: error
 
-	def handle_checkin(_conn, _from, conn, pool_state) do
-		{:ok, conn, pool_state}
-	end
+  # can't fail, but prove a ! variant for consistency
+  def rows({:ok, result}), do: {:ok, result.rows}
+  def rows(%Result{} = result), do: {:ok, result.rows}
+  def rows(error), do: error
+  def rows!({:ok, result}), do: result.rows
+  def rows!(%Result{} = result), do: result.rows
+  def rows!({:error, err}), do: raise(err)
 
-	@impl NimblePool
-	def terminate_worker(_reason, nil, pool_state), do: {:ok, pool_state}
-	def terminate_worker(_reason, conn, pool_state) do
-		Connection.close(conn)
-		{:ok, pool_state}
-	end
+  def row({:ok, result}) do
+    case result.rows do
+      [] -> {:ok, nil}
+      [row] -> {:ok, row}
+      _ -> {:error, Monet.Error.new(:client, "row called but multiple rows returned")}
+    end
+  end
 
-	# Once we've successfully connected, we want to reset the pool's failure count
-	defp reset(state) do
-		case pool(state, :failures) do
-			0 -> state
-			_ -> pool(state, failures: 0)
-		end
-	end
+  def row(%Result{} = result), do: row({:ok, result})
+  def row(error), do: error
+  def row!({:ok, _} = result), do: unwrap!(row(result))
+  def row!(%Result{} = result), do: unwrap!(row({:ok, result}))
+  def row!({:error, err}), do: raise(err)
 
-	defp backoff(state) do
-		failures = pool(state, :failures)
-		case failures do
-			0 -> :ok
-			1 -> :ok
-			2 -> :timer.sleep(100)
-			3 -> :timer.sleep(300)
-			4 -> :timer.sleep(600)
-			5 -> :timer.sleep(1000)
-			6 -> :timer.sleep(2000)
-			7 -> :timer.sleep(3000)
-			_ -> :timer.sleep(4000)
-		end
-		pool(state, failures: failures + 1)
-	end
+  def maps(input, opts \\ [])
+
+  def maps({:ok, result}, opts) do
+    {:ok, result |> as_map(opts) |> Enum.to_list()}
+  end
+
+  def maps(%Result{} = result, opts), do: maps({:ok, result}, opts)
+  def maps(error, _opts), do: error
+
+  def maps!(input, opts \\ [])
+  def maps!({:ok, _} = result, opts), do: result |> as_map(opts) |> Enum.to_list()
+  def maps!(%Result{} = result, opts), do: maps!({:ok, result}, opts)
+  def maps!({:error, err}, _opts), do: raise(err)
+
+  def map(input, opts \\ [])
+
+  def map({:ok, result}, opts) do
+    case result.rows do
+      [] ->
+        {:ok, nil}
+
+      [row] ->
+        row =
+          result.columns
+          |> columns_for_map(opts)
+          |> Enum.zip(row)
+          |> Map.new()
+
+        {:ok, row}
+
+      _ ->
+        {:error, Monet.Error.new(:client, "map called but multiple rows returned")}
+    end
+  end
+
+  def map(%Result{} = result, opts), do: map({:ok, result}, opts)
+  def map(error, _opts), do: error
+
+  def map!(input, opts \\ [])
+  def map!({:ok, _} = result, opts), do: unwrap!(map(result, opts))
+  def map!(%Result{} = result, opts), do: unwrap!(map({:ok, result}, opts))
+  def map!({:error, err}, _opts), do: raise(err)
+
+  def scalar({:ok, result}) do
+    case result.rows do
+      [] -> {:ok, nil}
+      [[value]] -> {:ok, value}
+      [_, _ | _] -> {:error, Monet.Error.new(:client, "scalar called but multiple rows returned")}
+      _ -> {:error, Monet.Error.new(:client, "scalar called but multiple columns returned")}
+    end
+  end
+
+  def scalar(%Result{} = result), do: scalar({:ok, result})
+  def scalar(error), do: error
+  def scalar!({:ok, _} = result), do: unwrap!(scalar(result))
+  def scalar!(%Result{} = result), do: unwrap!(scalar({:ok, result}))
+  def scalar!({:error, err}), do: raise(err)
+
+  defp unwrap!({:ok, result}), do: result
+  defp unwrap!({:error, err}), do: raise(err)
+
+  defp columns_for_map(columns, opts) do
+    case opts[:columns] do
+      :atoms -> Enum.map(columns, &String.to_atom/1)
+      _ -> columns
+    end
+  end
+
+  @impl NimblePool
+  def init_pool(state) do
+    name = Keyword.fetch!(pool(state, :config), :name)
+    # table is used by the transaction prepared statement cache
+    :ets.new(name, [:set, :public, :named_table])
+    {:ok, state}
+  end
+
+  @impl NimblePool
+  def init_worker(state) do
+    with {:ok, conn} <- Connection.connect(pool(state, :config)),
+         :ok <- Connection.controlling_process(conn, self()) do
+      {:ok, conn, reset(state)}
+    else
+      _ -> {:ok, nil, backoff(state)}
+    end
+  end
+
+  @impl NimblePool
+  def handle_checkout(:checkout, _, nil, state) do
+    failures = pool(state, :failures)
+    # micro-opt, bu thtere's no point in increasing this value any more since
+    # we've reached our max backoff
+    state =
+      case failures > 10 do
+        true -> state
+        false -> pool(state, failures: failures + 1)
+      end
+
+    {:remove, :down, state}
+  end
+
+  def handle_checkout(:checkout, {_pid, _}, conn, state) do
+    {:ok, conn, conn, state}
+  end
+
+  @impl NimblePool
+  def handle_checkin(nil, _from, _conn, pool_state) do
+    {:remove, :closed, pool_state}
+  end
+
+  def handle_checkin(_conn, _from, conn, pool_state) do
+    {:ok, conn, pool_state}
+  end
+
+  @impl NimblePool
+  def terminate_worker(_reason, nil, pool_state), do: {:ok, pool_state}
+
+  def terminate_worker(_reason, conn, pool_state) do
+    Connection.close(conn)
+    {:ok, pool_state}
+  end
+
+  # Once we've successfully connected, we want to reset the pool's failure
+  # count
+  defp reset(state) do
+    case pool(state, :failures) do
+      0 -> state
+      _ -> pool(state, failures: 0)
+    end
+  end
+
+  defp backoff(state) do
+    failures = pool(state, :failures)
+
+    case failures do
+      0 -> :ok
+      1 -> :ok
+      2 -> :timer.sleep(100)
+      3 -> :timer.sleep(300)
+      4 -> :timer.sleep(600)
+      5 -> :timer.sleep(1000)
+      6 -> :timer.sleep(2000)
+      7 -> :timer.sleep(3000)
+      _ -> :timer.sleep(4000)
+    end
+
+    pool(state, failures: failures + 1)
+  end
 end

--- a/lib/prepared.ex
+++ b/lib/prepared.ex
@@ -1,191 +1,194 @@
 defmodule Monet.Prepared do
-	@moduledoc false
+  @moduledoc false
 
-	# There's nothing to like about this. Ideally, I feel that we should be able
-	# to execute a prepared statement with just the id. But that isn't the case.
-	# First,  need to encode some values with a prefix:
-	#
-	#    exec 7(23, time '01:20:33', date '2010-02-10', blob '0AF3')
-	#
-	# Second, we sometimes need to include the precision:
-	#
-	#    exec 7(23, time(3) '01:20:33.993',
-	#
-	# So we need to parse the response to extract the types (we can't infer it
-	# from the supplies values because (a) we can't tell a text from a blob and
-	# (b) we need the precision for time.
-	#
-	# What's even worse though is that the prepared result includes other values.
-	# For example, if we do:
-	#
-	#    prepare "select ? - 1"
-	#
-	# We'll actually get 2 types back. So we need to only select the 'placeholder'
-	# types.
-	#
-	# AFAIC, the server could take care of all of this.
+  # There's nothing to like about this. Ideally, I feel that we should be able
+  # to execute a prepared statement with just the id. But that isn't the case.
+  # First,  need to encode some values with a prefix:
+  #
+  #    exec 7(23, time '01:20:33', date '2010-02-10', blob '0AF3')
+  #
+  # Second, we sometimes need to include the precision:
+  #
+  #    exec 7(23, time(3) '01:20:33.993',
+  #
+  # So we need to parse the response to extract the types (we can't infer it
+  # from the supplies values because (a) we can't tell a text from a blob and
+  # (b) we need the precision for time.
+  #
+  # What's even worse though is that the prepared result includes other values.
+  # For example, if we do:
+  #
+  #    prepare "select ? - 1"
+  #
+  # We'll actually get 2 types back. So we need to only select the
+  # 'placeholder' types.
+  #
+  # AFAIC, the server could take care of all of this.
 
-	require Record
-	alias Monet.{Error, Reader, Writer}
+  require Record
+  alias Monet.{Error, Reader, Writer}
 
-	Record.defrecord(:prepared, id: nil, conn: nil, types: nil)
+  Record.defrecord(:prepared, id: nil, conn: nil, types: nil)
 
-	@doc """
-	Parses the response from a "prepare STATMENT" query and builds up an object
-	that can be executed.
+  @doc """
+   Parses the response from a "prepare STATMENT" query and builds up an object
+   that can be executed.
 
-	Of importance here is a) getting the id  b) getting the types
-	"""
-	def new(conn, sql) do
-		with :ok, Writer.query(conn, ["prepare ", sql]),
-		     {:ok, data} <- Reader.message(conn)
-		do
-			build(conn, data)
-		end
-	end
+   Of importance here is a) getting the id  b) getting the types
+  """
+  def new(conn, sql) do
+    with :ok, Writer.query(conn, ["prepare ", sql]), {:ok, data} <- Reader.message(conn) do
+      build(conn, data)
+    end
+  end
 
-	@doc false
-	def build(conn, <<"&5 ", data::binary>>) do
-		case String.split(data, "\n", parts: 6) do
-			# The ignored 4 lines seem pretty meaningless. I think it's to be consistent
-			# with a select result. But we can parse this a little more efficiently knowing
-			# that it's from a prepared statement.
-			[header, _, _, _, _, rows] ->
-				with {:ok, id} <- parse_id(header),
-				     {:ok, types} <- parse_types(rows)
-				do
-					{:ok, prepared(id: id, conn: conn, types: types)}
-				end
-			_ -> {:error, Error.new(:driver, "invalid prepared response (1)", data)}
-		end
-	end
+  @doc false
+  def build(conn, <<"&5 ", data::binary>>) do
+    case String.split(data, "\n", parts: 6) do
+      # The ignored 4 lines seem pretty meaningless. I think it's to be
+      # consistent with a select result. But we can parse this a little more
+      # efficiently knowing that it's from a prepared statement.
+      [header, _, _, _, _, rows] ->
+        with {:ok, id} <- parse_id(header),
+             {:ok, types} <- parse_types(rows) do
+          {:ok, prepared(id: id, conn: conn, types: types)}
+        end
 
-	def build(_conn, invalid) do
-		{:error, Error.new(:driver, "invalid prepared response (2)", invalid)}
-	end
+      _ ->
+        {:error, Error.new(:driver, "invalid prepared response (1)", data)}
+    end
+  end
 
-	@doc """
-	Executes the prepared statement with the given argument.
+  def build(_conn, invalid) do
+    {:error, Error.new(:driver, "invalid prepared response (2)", invalid)}
+  end
 
-	It's up to the caller to cleanup (deallocate) the prepared statement when
-	they are done with it.
+  @doc """
+   Executes the prepared statement with the given argument.
 
-	Note that, on execution error, MonetDB autoamtically deallocates the prepared
-	statement. This seems rather annoying, but it's up to the caller to track such
-	errors and stop using (or re-prepare the query).
-	"""
-	def exec(p, args) do
-		conn = prepared(p, :conn)
-		args = Writer.encode(args, prepared(p, :types))
-		with :ok <- Writer.query(conn, ["exec " , prepared(p, :id), ?(, args, ?)]) do
-			Reader.result(conn)
-		end
-	end
+   It's up to the caller to cleanup (deallocate) the prepared statement when
+   they are done with it.
 
-	@doc """
-	Closes / deallocates the prepared statement.
-	"""
-	def close(p) do
-		conn = prepared(p, :conn)
-		with :ok <- Writer.query(conn, ["deallocate ", prepared(p, :id)]),
-		     {:ok, _} <- Reader.result(conn) # drain the response
-		do
-			:ok
-		end
-	end
+   Note that, on execution error, MonetDB autoamtically deallocates the prepared
+   statement. This seems rather annoying, but it's up to the caller to track
+   such errors and stop using (or re-prepare the query).
+  """
+  def exec(p, args) do
+    conn = prepared(p, :conn)
+    args = Writer.encode(args, prepared(p, :types))
 
-	@doc """
-	Calls exec/2 followed by close/1
-	"""
-	def exec_and_close(p, args) do
-		result = exec(p, args)
-		close(p)
-		result
-	end
+    with :ok <- Writer.query(conn, ["exec ", prepared(p, :id), ?(, args, ?)]) do
+      Reader.result(conn)
+    end
+  end
 
-	@doc """
-	Like exec_and_close/2 but returns both the result of the exec/2 as well as the
-	output from close/1.
+  @doc """
+   Closes / deallocates the prepared statement.
+  """
+  def close(p) do
+    conn = prepared(p, :conn)
 
-	This is used by Monet.Connection and the Monet pool manager to figure out
-	whether the connection should be returned to the pool or not.
+    with :ok <- Writer.query(conn, ["deallocate ", prepared(p, :id)]),
+         # drain the response
+         {:ok, _} <- Reader.result(conn) do
+      :ok
+    end
+  end
 
-	If exec/2 suceeds but close/1 errors, we'll still return the result from exec
-	but we'll also remove the connection from the pool.
-	"""
-	def exec_and_close2(p, args) do
-		result = exec(p, args)
-		{result, close(p)}
-	end
+  @doc """
+   Calls `exec/2` followed by `close/1`.
+  """
+  def exec_and_close(p, args) do
+    result = exec(p, args)
+    close(p)
+    result
+  end
 
-	defp parse_id(header) do
-		case :binary.split(header, " ") do
-			[id, _] -> {:ok, id}
-			_ -> {:error, Error.new(:driver, "invalid prepare header", header)}
-		end
-	end
+  @doc """
+  Like `exec_and_close/2` but returns both the result of the `exec/2` as well as the
+  output from close/1.
 
-	defp parse_types(data) do
-		parse_types(data, [])
-	end
+  This is used by `Monet.Connection` and the Monet pool manager to figure out
+  whether the connection should be returned to the pool or not.
 
-	defp parse_types(<<"[ \"blob\",\t", rest::binary>>, acc) do
-		case is_placeholder(rest) do
-			{true, next} -> parse_types(next, [:blob | acc])
-			{false, next} -> parse_types(next, acc)
-		end
-	end
+  If `exec/2` suceeds but `close/1` errors, we'll still return the result from exec
+  but we'll also remove the connection from the pool.
+  """
+  def exec_and_close2(p, args) do
+    result = exec(p, args)
+    {result, close(p)}
+  end
 
-	defp parse_types(<<"[ \"json\",\t", rest::binary>>, acc) do
-		case is_placeholder(rest) do
-			{true, next} -> parse_types(next, [:json | acc])
-			{false, next} -> parse_types(next, acc)
-		end
-	end
+  defp parse_id(header) do
+    case :binary.split(header, " ") do
+      [id, _] -> {:ok, id}
+      _ -> {:error, Error.new(:driver, "invalid prepare header", header)}
+    end
+  end
 
-	defp parse_types(<<"[ \"uuid\",\t", rest::binary>>, acc) do
-		case is_placeholder(rest) do
-			{true, next} -> parse_types(next, [:uuid | acc])
-			{false, next} -> parse_types(next, acc)
-		end
-	end
+  defp parse_types(data) do
+    parse_types(data, [])
+  end
 
-	for type <- [:time, :timestamp, :timestamptz] do
-		prefix = "[ \"#{type}\",\t"
-		defp parse_types(<<unquote(prefix), rest::binary>> = data, acc) do
-			case Integer.parse(rest) do
-				{size, _} ->
-					case is_placeholder(rest) do
-						{true, next} -> parse_types(next, [{unquote(type), size - 1} | acc])
-						{false, next} -> parse_types(next, acc)
-					end
-				:error -> {:error, Error.new(:driver, "invalid prepared row (#{unquote(type)})", data)}
-			end
-		end
-	end
+  defp parse_types(<<"[ \"blob\",\t", rest::binary>>, acc) do
+    case is_placeholder(rest) do
+      {true, next} -> parse_types(next, [:blob | acc])
+      {false, next} -> parse_types(next, acc)
+    end
+  end
 
-	defp parse_types(<<"[ \"", rest::binary>>, acc) do
-		case is_placeholder(rest) do
-			{true, next} -> parse_types(next, [nil | acc])
-			{false, next} -> parse_types(next, acc)
-		end
-	end
+  defp parse_types(<<"[ \"json\",\t", rest::binary>>, acc) do
+    case is_placeholder(rest) do
+      {true, next} -> parse_types(next, [:json | acc])
+      {false, next} -> parse_types(next, acc)
+    end
+  end
 
-	defp parse_types("", acc), do: {:ok, Enum.reverse(acc)}
+  defp parse_types(<<"[ \"uuid\",\t", rest::binary>>, acc) do
+    case is_placeholder(rest) do
+      {true, next} -> parse_types(next, [:uuid | acc])
+      {false, next} -> parse_types(next, acc)
+    end
+  end
 
-	defp parse_types(invalid, _acc) do
-		{:error, Error.new(:driver, "invalid prepared row (2)", invalid)}
-	end
+  for type <- [:time, :timestamp, :timestamptz] do
+    prefix = "[ \"#{type}\",\t"
 
-	# Figures out whether this is a placeholder or not and, either way, moves
-	# to the next row
-	defp is_placeholder(<<rest::binary>>) do
-		with [row, rest] <- :binary.split(rest, "\n") do
-			placeholder? = String.ends_with?(row, "NULL,\tNULL,\tNULL\t]")
-			{placeholder?, rest}
-		else
-			_ -> {false, rest}
-		end
-	end
+    defp parse_types(<<unquote(prefix), rest::binary>> = data, acc) do
+      case Integer.parse(rest) do
+        {size, _} ->
+          case is_placeholder(rest) do
+            {true, next} -> parse_types(next, [{unquote(type), size - 1} | acc])
+            {false, next} -> parse_types(next, acc)
+          end
+
+        :error ->
+          {:error, Error.new(:driver, "invalid prepared row (#{unquote(type)})", data)}
+      end
+    end
+  end
+
+  defp parse_types(<<"[ \"", rest::binary>>, acc) do
+    case is_placeholder(rest) do
+      {true, next} -> parse_types(next, [nil | acc])
+      {false, next} -> parse_types(next, acc)
+    end
+  end
+
+  defp parse_types("", acc), do: {:ok, Enum.reverse(acc)}
+
+  defp parse_types(invalid, _acc) do
+    {:error, Error.new(:driver, "invalid prepared row (2)", invalid)}
+  end
+
+  # Figures out whether this is a placeholder or not and, either way, moves to
+  # the next row.
+  defp is_placeholder(<<rest::binary>>) do
+    with [row, rest] <- :binary.split(rest, "\n") do
+      placeholder? = String.ends_with?(row, "NULL,\tNULL,\tNULL\t]")
+      {placeholder?, rest}
+    else
+      _ -> {false, rest}
+    end
+  end
 end
-

--- a/lib/query/select.ex
+++ b/lib/query/select.ex
@@ -1,143 +1,156 @@
 defmodule Monet.Query.Select do
-	@moduledoc """
-	A simple query builder.
+  @moduledoc """
+  A simple query builder.
 
-			rows = Select.new()
-			|> Select.columns("u.id, u.name")
-			|> Select.from("users u")
-			|> Select.join("roles r on u.role_id = r.id")
-			|> Select.where("u.power", :gt, 9000)
-			|> Select.limit(100)
-			|> Select.exec!()  // returns a Monet.Result
-			|> Monet.rows()
-	"""
-	use Monet.Query.Where
+  		rows = Select.new()
+  		|> Select.columns("u.id, u.name")
+  		|> Select.from("users u")
+  		|> Select.join("roles r on u.role_id = r.id")
+  		|> Select.where("u.power", :gt, 9000)
+  		|> Select.limit(100)
+  		|> Select.exec!()  // returns a Monet.Result
+  		|> Monet.rows()
+  """
+  use Monet.Query.Where
 
-	defmacro __using__(_) do
-		quote do
-			use Monet.Query.Where
-			alias Monet.Query.Select
-		end
-	end
+  defmacro __using__(_) do
+    quote do
+      use Monet.Query.Where
+      alias Monet.Query.Select
+    end
+  end
 
-	alias __MODULE__
+  alias __MODULE__
 
-	@enforce_keys [:select, :from, :where, :order, :group, :limit, :offset]
-	defstruct @enforce_keys
+  @enforce_keys [:select, :from, :where, :order, :group, :limit, :offset]
+  defstruct @enforce_keys
 
-	def new() do
-		%Select{
-			from: [],
-			order: nil,
-			group: nil,
-			limit: nil,
-			offset: nil,
-			select: nil,
-			where: Where.new(),
-		}
-	end
+  def new() do
+    %Select{
+      from: [],
+      order: nil,
+      group: nil,
+      limit: nil,
+      offset: nil,
+      select: nil,
+      where: Where.new()
+    }
+  end
 
-	@doc """
-	Columns to select. If not called, will select *.
-	Can can called multiple times. Can be called with an array, or a string.
-	This can really be anything and it's best to think of it as the test that
-	is placed between the `select` and the `from.
-	"""
-	def columns(q, [first | columns]) do
-		columns = Enum.reduce(columns, [first], fn c, acc -> [acc, ", ", c] end)
-		append_columns(q, columns)
-	end
-	def columns(s, column), do: append_columns(s, column)
-	defp append_columns(%{select: nil} = s, columns), do: %Select{s | select: columns}
-	defp append_columns(s, columns), do: %Select{s | select: [s.select, ", ", columns]}
+  @doc """
+  Columns to select. If not called, will select *.
+  Can can called multiple times. Can be called with an array, or a string.
+  This can really be anything and it's best to think of it as the test that
+  is placed between the `select` and the `from.
+  """
+  def columns(q, [first | columns]) do
+    columns = Enum.reduce(columns, [first], fn c, acc -> [acc, ", ", c] end)
+    append_columns(q, columns)
+  end
 
-	@doc """
-	Table to select from. Can be called multiple times. This essentially becomes
-	what gets placed between the "from" and the "where".
+  def columns(s, column), do: append_columns(s, column)
+  defp append_columns(%{select: nil} = s, columns), do: %Select{s | select: columns}
+  defp append_columns(s, columns), do: %Select{s | select: [s.select, ", ", columns]}
 
-	You could do:
-			Select.from(s, "users")
-			# OR
-			Select.from(s, "(select 1 from another) x")
-	"""
-	def from(s, from), do: %Select{s | from: [s.from, from]}
+  @doc """
+  Table to select from. Can be called multiple times. This essentially becomes
+  what gets placed between the "from" and the "where".
 
-	@doc """
-	Join tables. There's no magic here. Doesn't know anything
-	about your tables (aka, you need to tell it what to join on):
+  You could do:
+  		Select.from(s, "users")
+  		# OR
+  		Select.from(s, "(select 1 from another) x")
+  """
+  def from(s, from), do: %Select{s | from: [s.from, from]}
 
-			Select.join(s, "table b on a.id = b.id")
+  @doc """
+  Join tables. There's no magic here. Doesn't know anything
+  about your tables (aka, you need to tell it what to join on):
 
-	This is just a shorthand for `from/2` but it injects the word
-	" [left|right|full]? join " for you
-	"""
-	def join(s, table), do: %Select{s | from: [s.from, [" join ", table]]}
-	def join(s, :left, table), do: %Select{s | from: [s.from, [" left join ", table]]}
-	def join(s, :right, table), do: %Select{s | from: [s.from, [" right join ", table]]}
-	def join(s, :full, table), do: %Select{s | from: [s.from, [" full join ", table]]}
+  		Select.join(s, "table b on a.id = b.id")
 
-	def order(s, order), do: append_order(s, order)
-	def order(s, order, true), do: append_order(s, order)
-	def order(s, order, false), do: append_order(s, [order, " desc"])
-	defp append_order(%{order: nil} = s, order), do: %Select{s | order: [order]}
-	defp append_order(%{order: existing} = s, order), do: %Select{s | order: [existing, ", ", order]}
+  This is just a shorthand for `from/2` but it injects the word
+  " [left|right|full]? join " for you
+  """
+  def join(s, table), do: %Select{s | from: [s.from, [" join ", table]]}
+  def join(s, :left, table), do: %Select{s | from: [s.from, [" left join ", table]]}
+  def join(s, :right, table), do: %Select{s | from: [s.from, [" right join ", table]]}
+  def join(s, :full, table), do: %Select{s | from: [s.from, [" full join ", table]]}
 
-	def group(s, group), do: %Select{s | group: group}
+  def order(s, order), do: append_order(s, order)
+  def order(s, order, true), do: append_order(s, order)
+  def order(s, order, false), do: append_order(s, [order, " desc"])
+  defp append_order(%{order: nil} = s, order), do: %Select{s | order: [order]}
 
-	def limit(s, limit) when is_integer(limit), do: %Select{s | limit: limit}
-	def offset(s, offset) when is_integer(offset), do: %Select{s | offset: offset}
+  defp append_order(%{order: existing} = s, order),
+    do: %Select{s | order: [existing, ", ", order]}
 
-	def exec(s, pool \\ Monet) do
-		{sql, args} = to_sql(s)
-		Monet.query(pool, sql, args)
-	end
+  def group(s, group), do: %Select{s | group: group}
 
-	def exec!(s, pool \\ Monet) do
-		case exec(s, pool) do
-			{:ok, result} -> result
-			{:error, err} -> raise err
-		end
-	end
+  def limit(s, limit) when is_integer(limit), do: %Select{s | limit: limit}
+  def offset(s, offset) when is_integer(offset), do: %Select{s | offset: offset}
 
-	def to_sql(s) do
-		{where, args} = Where.to_sql(s.where)
-		sql = ["select ", s.select || "*", " from ", s.from, where]
+  def exec(s, pool \\ Monet) do
+    {sql, args} = to_sql(s)
+    Monet.query(pool, sql, args)
+  end
 
-		sql = case s.group do
-			nil -> sql
-			group -> [sql, " group by ", group]
-		end
+  def exec!(s, pool \\ Monet) do
+    case exec(s, pool) do
+      {:ok, result} -> result
+      {:error, err} -> raise err
+    end
+  end
 
-		sql = case s.order do
-			nil -> sql
-			order -> [sql, " order by ", order]
-		end
+  def to_sql(s) do
+    {where, args} = Where.to_sql(s.where)
+    sql = ["select ", s.select || "*", " from ", s.from, where]
 
-		sql = case s.limit do
-			nil -> sql
-			limit -> [sql, " limit ", Integer.to_string(limit)]
-		end
+    sql =
+      case s.group do
+        nil -> sql
+        group -> [sql, " group by ", group]
+      end
 
-		sql = case s.offset do
-			nil -> sql
-			offset -> [sql, " offset ", Integer.to_string(offset)]
-		end
+    sql =
+      case s.order do
+        nil -> sql
+        order -> [sql, " order by ", order]
+      end
 
-		{sql, args}
-	end
+    sql =
+      case s.limit do
+        nil -> sql
+        limit -> [sql, " limit ", Integer.to_string(limit)]
+      end
 
+    sql =
+      case s.offset do
+        nil -> sql
+        offset -> [sql, " offset ", Integer.to_string(offset)]
+      end
+
+    {sql, args}
+  end
 end
 
 defimpl Inspect, for: Monet.Query.Select do
-	def inspect(q, opts) do
-		import Inspect.Algebra
-		{sql, values} = Monet.Query.Select.to_sql(q)
-		sql = :erlang.iolist_to_binary(sql)
-		sql = Regex.split(~r/ (from|join|where|order by|limit|offset) /, sql, include_captures: true)
-		docs = fold_doc(sql, fn
-			<<" ", doc::binary>>, acc when doc in ["from ", "join", "where ", "group by", "order by ", "limit ", "offset "] -> concat([break("\n"), doc, acc])
-			doc, acc -> concat(doc, acc)
-		end)
-		concat [docs, break("\n"), to_doc(values, opts)]
-	end
+  def inspect(q, opts) do
+    import Inspect.Algebra
+    {sql, values} = Monet.Query.Select.to_sql(q)
+    sql = :erlang.iolist_to_binary(sql)
+    sql = Regex.split(~r/ (from|join|where|order by|limit|offset) /, sql, include_captures: true)
+
+    docs =
+      fold_doc(sql, fn
+        <<" ", doc::binary>>, acc
+        when doc in ["from ", "join", "where ", "group by", "order by ", "limit ", "offset "] ->
+          concat([break("\n"), doc, acc])
+
+        doc, acc ->
+          concat(doc, acc)
+      end)
+
+    concat([docs, break("\n"), to_doc(values, opts)])
+  end
 end

--- a/lib/query/where.ex
+++ b/lib/query/where.ex
@@ -1,122 +1,136 @@
 defmodule Monet.Query.Where do
-	alias __MODULE__
+  alias __MODULE__
 
-	defmacro __using__(_) do
-		quote location: :keep do
-			alias Monet.Query.Where
+  defmacro __using__(_) do
+    quote location: :keep do
+      alias Monet.Query.Where
 
-			def where_ignore_nil(q, _, _, nil), do: q
-			def where_ignore_nil(q, column, op, value), do: where(q, column, op, value)
+      def where_ignore_nil(q, _, _, nil), do: q
+      def where_ignore_nil(q, column, op, value), do: where(q, column, op, value)
 
-			def where(q, column, :eq, value) do
-				%{q | where: Where.eq(q.where, column, value)}
-			end
+      def where(q, column, :eq, value) do
+        %{q | where: Where.eq(q.where, column, value)}
+      end
 
-			def where(q, column, :ne, value) do
-				%{q | where: Where.ne(q.where, column, value)}
-			end
+      def where(q, column, :ne, value) do
+        %{q | where: Where.ne(q.where, column, value)}
+      end
 
-			def where(q, column, :gt, value) do
-				%{q | where: Where.gt(q.where, column, value)}
-			end
+      def where(q, column, :gt, value) do
+        %{q | where: Where.gt(q.where, column, value)}
+      end
 
-			def where(q, column, :gte, value) do
-				%{q | where: Where.gte(q.where, column, value)}
-			end
+      def where(q, column, :gte, value) do
+        %{q | where: Where.gte(q.where, column, value)}
+      end
 
-			def where(q, column, :lt, value) do
-				%{q | where: Where.lt(q.where, column, value)}
-			end
+      def where(q, column, :lt, value) do
+        %{q | where: Where.lt(q.where, column, value)}
+      end
 
-			def where(q, column, :lte, value) do
-				%{q | where: Where.lte(q.where, column, value)}
-			end
+      def where(q, column, :lte, value) do
+        %{q | where: Where.lte(q.where, column, value)}
+      end
 
-			def where(q, column, :like, value) do
-				%{q | where: Where.like(q.where, column, value)}
-			end
+      def where(q, column, :like, value) do
+        %{q | where: Where.like(q.where, column, value)}
+      end
 
-			@where_op [:eq, :ne, :gt, :gte, :lt, :lte, :like]
-			defmacro where_and(q, fun) do
-				fun = Macro.postwalk(fun, fn
-					{op, line, args} when op in @where_op -> {{:., line, [{:__aliases__, line, [:Monet, :Query, :Where]}, op]}, line, args}
-					expr -> expr
-				end)
-				quote location: :keep do
-					where = unquote(q).where
-					where = Where.where_fun(where, unquote(fun), " and ")
-					%{unquote(q) | where: where}
-				end
-			end
+      @where_op [:eq, :ne, :gt, :gte, :lt, :lte, :like]
+      defmacro where_and(q, fun) do
+        fun =
+          Macro.postwalk(fun, fn
+            {op, line, args} when op in @where_op ->
+              {{:., line, [{:__aliases__, line, [:Monet, :Query, :Where]}, op]}, line, args}
 
-			defmacro where_or(q, fun) do
-				fun = Macro.postwalk(fun, fn
-					{op, line, args} when op in @where_op -> {{:., line, [{:__aliases__, line, [:Monet, :Query, :Where]}, op]}, line, args}
-					expr -> expr
-				end)
-				quote location: :keep do
-					where = unquote(q).where
-					where = Where.where_fun(where, unquote(fun), " or ")
-					%{unquote(q) | where: where}
-				end
-			end
-		end
-	end
+            expr ->
+              expr
+          end)
 
-	@enforce_keys [:sql, :op, :values]
-	defstruct @enforce_keys
+        quote location: :keep do
+          where = unquote(q).where
+          where = Where.where_fun(where, unquote(fun), " and ")
+          %{unquote(q) | where: where}
+        end
+      end
 
-	def new() do
-		%Where{
-			sql: nil,
-			op: " and ",
-			values: [],
-		}
-	end
+      defmacro where_or(q, fun) do
+        fun =
+          Macro.postwalk(fun, fn
+            {op, line, args} when op in @where_op ->
+              {{:., line, [{:__aliases__, line, [:Monet, :Query, :Where]}, op]}, line, args}
 
-	# need this so that the is_atom guard doesn't pick it up and try to convert
-	# our true/false atom to a string
-	def eq(w, column, nil), do: append(w, [column, " is null"])
-	def eq(w, column, value) when is_boolean(value), do: append(w, column, " = ", value)
-	def eq(w, column, value) when is_atom(value), do: eq(w, column, Atom.to_string(value))
-	def eq(w, column, value), do: append(w, column, " = ", value)
+            expr ->
+              expr
+          end)
 
-	def ne(w, column, nil), do: append(w, [column, " is not null"])
-	def ne(w, column, value) when is_boolean(value), do: append(w, column, " != ", value)
-	def ne(w, column, value) when is_atom(value), do: ne(w, column, Atom.to_string(value))
-	def ne(w, column, value), do: append(w, column, " != ", value)
+        quote location: :keep do
+          where = unquote(q).where
+          where = Where.where_fun(where, unquote(fun), " or ")
+          %{unquote(q) | where: where}
+        end
+      end
+    end
+  end
 
-	def gt(w, column, value), do: append(w, column, " > ", value)
-	def gte(w, column, value), do: append(w, column, " >= ", value)
+  @enforce_keys [:sql, :op, :values]
+  defstruct @enforce_keys
 
-	def lt(w, column, value), do: append(w, column, " < ", value)
-	def lte(w, column, value), do: append(w, column, " <= ", value)
+  def new() do
+    %Where{
+      sql: nil,
+      op: " and ",
+      values: []
+    }
+  end
 
-	def like(w, column, value), do: append(w, column, " like ", value)
+  # need this so that the is_atom guard doesn't pick it up and try to convert
+  # our true/false atom to a string
+  def eq(w, column, nil), do: append(w, [column, " is null"])
+  def eq(w, column, value) when is_boolean(value), do: append(w, column, " = ", value)
+  def eq(w, column, value) when is_atom(value), do: eq(w, column, Atom.to_string(value))
+  def eq(w, column, value), do: append(w, column, " = ", value)
 
-	def where_fun(where, fun, op) do
-		outer = case where.sql do
-			nil -> [" where ("]
-			sql -> [sql, where.op, "("]
-		end
-		where = %Where{where | sql: :group, op: op}
-		where = fun.(where)
-		%Where{where | sql: [outer, where.sql, ") "], op: " and "}
-	end
+  def ne(w, column, nil), do: append(w, [column, " is not null"])
+  def ne(w, column, value) when is_boolean(value), do: append(w, column, " != ", value)
+  def ne(w, column, value) when is_atom(value), do: ne(w, column, Atom.to_string(value))
+  def ne(w, column, value), do: append(w, column, " != ", value)
 
-	def to_sql(w), do: {w.sql || "", Enum.reverse(w.values)}
+  def gt(w, column, value), do: append(w, column, " > ", value)
+  def gte(w, column, value), do: append(w, column, " >= ", value)
 
-	defp append(w, filter) do
-		sql = case w.sql do
-			nil -> [" where ", filter]
-			:group -> [filter]
-			acc -> [acc, w.op, filter]
-		end
-		%Where{w | sql: sql}
-	end
+  def lt(w, column, value), do: append(w, column, " < ", value)
+  def lte(w, column, value), do: append(w, column, " <= ", value)
 
-	defp append(w, column, op, value) do
-		w = append(w, [column, op, ??])
-		%Where{w | values: [value | w.values]}
-	end
+  def like(w, column, value), do: append(w, column, " like ", value)
+
+  def where_fun(where, fun, op) do
+    outer =
+      case where.sql do
+        nil -> [" where ("]
+        sql -> [sql, where.op, "("]
+      end
+
+    where = %Where{where | sql: :group, op: op}
+    where = fun.(where)
+    %Where{where | sql: [outer, where.sql, ") "], op: " and "}
+  end
+
+  def to_sql(w), do: {w.sql || "", Enum.reverse(w.values)}
+
+  defp append(w, filter) do
+    sql =
+      case w.sql do
+        nil -> [" where ", filter]
+        :group -> [filter]
+        acc -> [acc, w.op, filter]
+      end
+
+    %Where{w | sql: sql}
+  end
+
+  defp append(w, column, op, value) do
+    w = append(w, [column, op, ??])
+    %Where{w | values: [value | w.values]}
+  end
 end

--- a/lib/reader.ex
+++ b/lib/reader.ex
@@ -1,401 +1,437 @@
 defmodule Monet.Reader do
-	@moduledoc """
-	Reads and parses responses from the server. Should not be called directly from
-	outside this library.
-	"""
-	use Bitwise, only: [bsr: 2, band: 1]
+  @moduledoc """
+  Reads and parses responses from the server. Should not be called directly
+  from outside this library.
+  """
+  use Bitwise, only: [bsr: 2, band: 1]
 
-	import NimbleParsec
-	import Monet.Connection, only: [connection: 2]
+  import NimbleParsec
+  import Monet.Connection, only: [connection: 2]
 
-	alias Monet.{Error, Result, Prepared}
+  alias Monet.{Error, Result, Prepared}
 
-	@doc "Reads the result from a query"
-	def result(conn) do
-		with {:ok, payload} <- message(conn, nil) do
-			parse_result(payload, conn)
-		end
-	end
+  @doc "Reads the result from a query"
+  def result(conn) do
+    with {:ok, payload} <- message(conn, nil) do
+      parse_result(payload, conn)
+    end
+  end
 
-	@doc "Reads a single message"
-	def message(conn, acc \\ nil) do
-		conn
-		|> read_n(2)
-		|> payload(conn, acc)
-	end
+  @doc "Reads a single message"
+  def message(conn, acc \\ nil) do
+    conn
+    |> read_n(2)
+    |> payload(conn, acc)
+  end
 
-	defp payload({:ok, <<1, 0>>}, _conn, _acc), do: {:ok, ""}
+  defp payload({:ok, <<1, 0>>}, _conn, _acc), do: {:ok, ""}
 
-	defp payload({:ok, <<header::little-16>>}, conn, acc) do
-		len = bsr(header, 1)
-		fin = band(header, 1)
+  defp payload({:ok, <<header::little-16>>}, conn, acc) do
+    len = bsr(header, 1)
+    fin = band(header, 1)
 
-		case read_n(conn, len) do
-			{:ok, <<"!", rest::binary>>} -> monet_error(rest)
-			{:ok, data} ->
-				cond do
-					fin == 0 -> message(conn, [acc || [], data])
-					acc == nil -> {:ok, data}
-					true -> {:ok, :erlang.iolist_to_binary([acc, data])}
-				end
-			err -> err
-		end
-	end
+    case read_n(conn, len) do
+      {:ok, <<"!", rest::binary>>} ->
+        monet_error(rest)
 
-	defp payload({:error, err}, _conn, _acc) do
-		{:error, Error.new(:network, err)}
-	end
+      {:ok, data} ->
+        cond do
+          fin == 0 -> message(conn, [acc || [], data])
+          acc == nil -> {:ok, data}
+          true -> {:ok, :erlang.iolist_to_binary([acc, data])}
+        end
 
-	defp monet_error(<<err::binary>>) do
-		{message, code} = case Integer.parse(err) do
-			{code, <<?!, message::binary>>} -> {message, code}
-			_ -> {err, nil}
-		end
-		{:error, %Error{source: :monetd, message: message, code: code}}
-	end
+      err ->
+        err
+    end
+  end
 
-	defp read_n(conn, n) do
-		socket = connection(conn, :socket)
-		timeout = connection(conn, :read_timeout)
-		:gen_tcp.recv(socket, n, timeout)
-	end
+  defp payload({:error, err}, _conn, _acc) do
+    {:error, Error.new(:network, err)}
+  end
 
-	# result from a select
-	defp parse_result(<<"&1 ", data::binary>>, _conn) do
-		case String.split(data, "\n", parts: 6) do
-			[header, _tables, columns, types, _length, rows] ->
-				with {:ok, types} <- parse_result_types(types),
-						 {:ok, row_count, header} <- parse_result_header(header),
-						 {:ok, columns} <- parse_result_columns(columns),
-						 {:ok, rows} <- parse_result_rows(row_count, types, rows)
-				do
-					{:ok, Result.new(header, columns, rows, row_count)}
-				end
-			_ -> {:error, Error.new(:driver, "invalid query response", data)}
-		end
-	end
+  defp monet_error(<<err::binary>>) do
+    {message, code} =
+      case Integer.parse(err) do
+        {code, <<?!, message::binary>>} -> {message, code}
+        _ -> {err, nil}
+      end
 
-	# result from an insert or update
-	defp parse_result(<<"&2 ", data::binary>>, _conn) do
-		with {row_count, <<" ", rest::binary>>} <- Integer.parse(data),
-				 {last_id, _} <- Integer.parse(rest)
-		do
-			{:ok, Result.upsert(data, row_count, last_id)}
-		else
-			_ -> {:error, Error.new(:driver, "invalid insert/update result", data)}
-		end
-	end
+    {:error, %Error{source: :monetd, message: message, code: code}}
+  end
 
-	# result from a create or drop
-	defp parse_result(<<"&3 ", data::binary>>, _conn) do
-		case :binary.split(data, "\n") do
-			[_, <<"!", rest::binary>>] -> monet_error(rest)
-			_ -> {:ok, Result.meta(String.trim_trailing(data))}
-		end
-	end
+  defp read_n(conn, n) do
+    socket = connection(conn, :socket)
+    timeout = connection(conn, :read_timeout)
+    :gen_tcp.recv(socket, n, timeout)
+  end
 
-	# Result from a transaction. We expect it to be in auto-commit false (hence the f)
-	defp parse_result("&4 f\n", _conn) do
-		{:ok, Result.meta("&4 f")}
-	end
+  # result from a select
+  defp parse_result(<<"&1 ", data::binary>>, _conn) do
+    case String.split(data, "\n", parts: 6) do
+      [header, _tables, columns, types, _length, rows] ->
+        with {:ok, types} <- parse_result_types(types),
+             {:ok, row_count, header} <- parse_result_header(header),
+             {:ok, columns} <- parse_result_columns(columns),
+             {:ok, rows} <- parse_result_rows(row_count, types, rows) do
+          {:ok, Result.new(header, columns, rows, row_count)}
+        end
 
-	# result from a prepared request
-	defp parse_result(<<"&5 ", _::binary>> = data, conn) do
-		Prepared.build(conn, data)
-	end
+      _ ->
+        {:error, Error.new(:driver, "invalid query response", data)}
+    end
+  end
 
-	# result from a QBLOCK ??
-	defp parse_result(<<"&6 ", _data::binary>>, _conn) do
-		raise "QBLOCK result parsing not implemented"
-	end
+  # result from an insert or update
+  defp parse_result(<<"&2 ", data::binary>>, _conn) do
+    with {row_count, <<" ", rest::binary>>} <- Integer.parse(data),
+         {last_id, _} <- Integer.parse(rest) do
+      {:ok, Result.upsert(data, row_count, last_id)}
+    else
+      _ -> {:error, Error.new(:driver, "invalid insert/update result", data)}
+    end
+  end
 
-	defp parse_result(<<unknown::binary>>, _conn) do
-		{:error, Error.new(:driver, "unknown query result", unknown)}
-	end
+  # result from a create or drop
+  defp parse_result(<<"&3 ", data::binary>>, _conn) do
+    case :binary.split(data, "\n") do
+      [_, <<"!", rest::binary>>] -> monet_error(rest)
+      _ -> {:ok, Result.meta(String.trim_trailing(data))}
+    end
+  end
 
-	defp parse_result_types(<<types::binary>>) do
-		l = byte_size(types) - 9
-		case types do
-			<<"% ", types::bytes-size(l), " # type">> -> {:ok, types |> String.split(",\t") |> Enum.map(&String.to_atom/1)}
-			_ -> {:error, Error.new(:driver, "invalid result type header", types)}
-		end
-	end
+  # Result from a transaction. We expect it to be in auto-commit false (hence
+  # the f).
+  defp parse_result("&4 f\n", _conn) do
+    {:ok, Result.meta("&4 f")}
+  end
 
-	defp parse_result_header(<<header::binary>>) do
-		with [_query_id, rest] <- :binary.split(header, " "),
-				 {row_count, _} <- Integer.parse(rest)
-		do
-			{:ok, row_count, header}
-		else
-			_ -> {:error, Error.new(:driver, "invalid result header", header)}
-		end
-	end
+  # Result from a prepared request.
+  defp parse_result(<<"&5 ", _::binary>> = data, conn) do
+    Prepared.build(conn, data)
+  end
 
-	defp parse_result_columns(<<columns::binary>>) do
-		l = byte_size(columns) - 9
-		case columns do
-			<<"% ", columns::bytes-size(l), " # name">> -> {:ok, String.split(columns, ",\t")}
-			_ -> {:error, Error.new(:driver, "invalid result columns header", columns)}
-		end
-	end
+  # Result from a QBLOCK ??
+  defp parse_result(<<"&6 ", _data::binary>>, _conn) do
+    raise "QBLOCK result parsing not implemented"
+  end
 
-	defp parse_result_rows(0, _types, <<_data::binary>>), do: {:ok, []}
+  defp parse_result(<<unknown::binary>>, _conn) do
+    {:error, Error.new(:driver, "unknown query result", unknown)}
+  end
 
-	defp parse_result_rows(_row_count, types, <<data::binary>>) do
-		do_parse_result_rows(types, data, [])
-	end
+  defp parse_result_types(<<types::binary>>) do
+    l = byte_size(types) - 9
 
-	defp do_parse_result_rows(types, <<data::binary>>, acc) do
-		case parse_row(types, data) do
-			{:ok, "", row} -> {:ok, Enum.reverse([row | acc])}
-			{:ok, rest, row} -> do_parse_result_rows(types, rest, [row | acc])
-			err -> err
-		end
-	end
+    case types do
+      <<"% ", types::bytes-size(l), " # type">> ->
+        {:ok, types |> String.split(",\t") |> Enum.map(&String.to_atom/1)}
 
-	# first value in the row, strip out the leading "[ "
-	defp parse_row(types, <<"[ ", data::binary>>) do
-		parse_row(types, data, [])
-	end
+      _ ->
+        {:error, Error.new(:driver, "invalid result type header", types)}
+    end
+  end
 
-	defp parse_row(_types, <<data::binary>>) do
-		{:error, Error.new(:driver, "invalid row prefix", data)}
-	end
+  defp parse_result_header(<<header::binary>>) do
+    with [_query_id, rest] <- :binary.split(header, " "),
+         {row_count, _} <- Integer.parse(rest) do
+      {:ok, row_count, header}
+    else
+      _ -> {:error, Error.new(:driver, "invalid result header", header)}
+    end
+  end
 
-	# last value in the row, special handling to strip out the trailing data
-	defp parse_row([type], <<data::binary>>, row) do
-		case parse_value(type, data) do
-			{:ok, <<"\t]\n", rest::binary>>, value} -> {:ok, rest, Enum.reverse([value | row])}
-			{:ok, {:text, <<"]\n", rest::binary>>}, value} -> {:ok, rest, Enum.reverse([value | row])}
-			{:ok, _, _} -> {:error, Error.new(:driver, "invalid row terminator", data)}
-			err -> err
-		end
-	end
+  defp parse_result_columns(<<columns::binary>>) do
+    l = byte_size(columns) - 9
 
-	defp parse_row([type | types], <<data::binary>>, row) do
-		case parse_value(type, data) do
-			{:ok, <<",\t", rest::binary>>, value} -> parse_row(types, rest, [value | row])
-			{:ok, {:text, <<rest::binary>>}, value} -> parse_row(types, rest, [value | row])
-			{:ok, _, _value} -> {:error, Error.new(:driver, "invalid value separator", data)}
-			err -> err
-		end
-	end
+    case columns do
+      <<"% ", columns::bytes-size(l), " # name">> -> {:ok, String.split(columns, ",\t")}
+      _ -> {:error, Error.new(:driver, "invalid result columns header", columns)}
+    end
+  end
 
-	defp parse_value(_type, <<"NULL", rest::binary>>), do: {:ok, rest, nil}
+  defp parse_result_rows(0, _types, <<_data::binary>>), do: {:ok, []}
 
-	defp parse_value(type, <<data::binary>>) when type in [:int, :tinyint, :bigint, :hugeint, :oid, :smallint, :serial] do
-		case Integer.parse(data) do
-			{value, rest} -> {:ok, rest, value}
-			:error -> {:error, Error.new(:driver, "invalid integer", data)}
-		end
-	end
+  defp parse_result_rows(_row_count, types, <<data::binary>>) do
+    do_parse_result_rows(types, data, [])
+  end
 
-	defp parse_value(type, <<data::binary>>) when type in [:double, :float, :real] do
-		case Float.parse(data) do
-			{value, rest} -> {:ok, rest, value}
-			:error -> {:error, Error.new(:driver, "invalid float", data)}
-		end
-	end
+  defp do_parse_result_rows(types, <<data::binary>>, acc) do
+    case parse_row(types, data) do
+      {:ok, "", row} -> {:ok, Enum.reverse([row | acc])}
+      {:ok, rest, row} -> do_parse_result_rows(types, rest, [row | acc])
+      err -> err
+    end
+  end
 
-	defp parse_value(:decimal, <<data::binary>>) do
-		case Decimal.parse(data) do
-			{value, rest} -> {:ok, rest, value}
-			:error -> {:error, Error.new(:driver, "invalid decimal", data)}
-		end
-	end
+  # first value in the row, strip out the leading "[ "
+  defp parse_row(types, <<"[ ", data::binary>>) do
+    parse_row(types, data, [])
+  end
 
-	defp parse_value(:boolean, <<"true", rest::binary>>), do: {:ok, rest, true}
-	defp parse_value(:boolean, <<"false", rest::binary>>), do: {:ok, rest, false}
-	defp parse_value(:boolean, invalid), do: {:error, Error.new(:driver, "invalid boolean", invalid)}
+  defp parse_row(_types, <<data::binary>>) do
+    {:error, Error.new(:driver, "invalid row prefix", data)}
+  end
 
-	@string_types [:char, :varchar, :clob, :text, :json]
-	defp parse_value(type, <<?", data::binary>>) when type in @string_types do
-		# Unlike the other functions, this actually strips out the trailing delimiter
-		# (the "\t" or ",\t" depending on if it's the last column or not).
-		# This breaks a lot of our parsing since we expect "rest" to not be consumed.
-		# To solve this, and to avoid re-concatenating the separator, we return a special
-		# "rest" of {:text, rest} which the other parses can special case.
+  # last value in the row, special handling to strip out the trailing data
+  defp parse_row([type], <<data::binary>>, row) do
+    case parse_value(type, data) do
+      {:ok, <<"\t]\n", rest::binary>>, value} -> {:ok, rest, Enum.reverse([value | row])}
+      {:ok, {:text, <<"]\n", rest::binary>>}, value} -> {:ok, rest, Enum.reverse([value | row])}
+      {:ok, _, _} -> {:error, Error.new(:driver, "invalid row terminator", data)}
+      err -> err
+    end
+  end
 
-		[string, rest] = :binary.split(data, "\t")
-		{:ok, {:text, rest}, string |> parse_string() |> :erlang.iolist_to_binary()}
-	end
+  defp parse_row([type | types], <<data::binary>>, row) do
+    case parse_value(type, data) do
+      {:ok, <<",\t", rest::binary>>, value} -> parse_row(types, rest, [value | row])
+      {:ok, {:text, <<rest::binary>>}, value} -> parse_row(types, rest, [value | row])
+      {:ok, _, _value} -> {:error, Error.new(:driver, "invalid value separator", data)}
+      err -> err
+    end
+  end
 
-	defp parse_value(type, <<invalid::binary>>) when type in @string_types do
-		{:error, Error.new(:driver, "invalid string prefix", invalid)}
-	end
+  defp parse_value(_type, <<"NULL", rest::binary>>), do: {:ok, rest, nil}
 
-	defp parse_value(:uuid, <<uuid::bytes-size(36), rest::binary>>) do
-		{:ok, rest, uuid}
-	end
+  defp parse_value(type, <<data::binary>>)
+       when type in [:int, :tinyint, :bigint, :hugeint, :oid, :smallint, :serial] do
+    case Integer.parse(data) do
+      {value, rest} -> {:ok, rest, value}
+      :error -> {:error, Error.new(:driver, "invalid integer", data)}
+    end
+  end
 
-	defp parse_value(:blob, <<data::binary>>) do
-		{value, rest} = extract_token(data)
-		case Base.decode16(value) do
-			{:ok, value} -> {:ok, rest, value}
-			:error -> {:error, Error.new(:driver, "invalid blob", data)}
-		end
-	end
+  defp parse_value(type, <<data::binary>>) when type in [:double, :float, :real] do
+    case Float.parse(data) do
+      {value, rest} -> {:ok, rest, value}
+      :error -> {:error, Error.new(:driver, "invalid float", data)}
+    end
+  end
 
-	defp parse_value(:time, <<data::binary>>) do
-		with {:ok, data, rest, _, _, _} <- extract_time(data),
-				 {:ok, time} <- build_time(data)
-		do
-			{:ok, rest, time}
-		else
-			_ -> {:error, Error.new(:driver, "invalid time", data)}
-		end
-	end
+  defp parse_value(:decimal, <<data::binary>>) do
+    case Decimal.parse(data) do
+      {value, rest} -> {:ok, rest, value}
+      :error -> {:error, Error.new(:driver, "invalid decimal", data)}
+    end
+  end
 
-	# MonetDB strips out any leading zeros from the year, so we can't use Date.from_iso8601
-	defp parse_value(:date, <<data::binary>>) do
-		with {:ok, [year, month, day], rest, _, _, _} <- extract_date(data),
-				 {:ok, date} <- Date.new(year, month, day)
-		do
-			{:ok, rest, date}
-		else
-			_ -> {:error, Error.new(:driver, "invalid date", data)}
-		end
-	end
+  defp parse_value(:boolean, <<"true", rest::binary>>), do: {:ok, rest, true}
+  defp parse_value(:boolean, <<"false", rest::binary>>), do: {:ok, rest, false}
 
-	defp parse_value(:timestamp, <<data::binary>>) do
-		with {:ok, <<" ", rest::binary>>, date} <- parse_value(:date, data),
-				 {:ok, rest, time} <- parse_value(:time, rest),
-				 {:ok, datetime} <- NaiveDateTime.new(date, time)
-		do
-			{:ok, rest, datetime}
-		else
-			_ -> {:error, Error.new(:driver, "invalid timestamp", data)}
-		end
-	end
+  defp parse_value(:boolean, invalid),
+    do: {:error, Error.new(:driver, "invalid boolean", invalid)}
 
-	# I'm pretty this timezone stuff isn't right
-	defp parse_value(:timestamptz, <<data::binary>>) do
-		with {:ok, <<" ", rest::binary>>, date} <- parse_value(:date, data),
-				 {:ok, rest, time} <- parse_value(:time, rest),
-				 {:ok, time_zone, rest, _, _, _} <- extract_time_zone(rest)
-		do
-			{timezone, abbreviation, offset} = build_time_zone(time_zone)
-			datetime = %DateTime{
-				year: date.year,
-				month: date.month,
-				day: date.day,
-				hour: time.hour,
-				minute: time.minute,
-				second: time.second,
-				microsecond: time.microsecond,
-				utc_offset: offset,
-				std_offset: 0, # ??
-				time_zone: timezone,
-				zone_abbr: abbreviation,
-			}
-			{:ok, rest, datetime}
-		else
-			_ -> {:error, Error.new(:driver, "invalid timestamptz", data)}
-		end
-	end
+  @string_types [:char, :varchar, :clob, :text, :json]
+  defp parse_value(type, <<?", data::binary>>) when type in @string_types do
+    # Unlike the other functions, this actually strips out the trailing delimiter
+    # (the "\t" or ",\t" depending on if it's the last column or not).
+    # This breaks a lot of our parsing since we expect "rest" to not be consumed.
+    # To solve this, and to avoid re-concatenating the separator, we return a special
+    # "rest" of {:text, rest} which the other parses can special case.
 
+    [string, rest] = :binary.split(data, "\t")
+    {:ok, {:text, rest}, string |> parse_string() |> :erlang.iolist_to_binary()}
+  end
 
-	defp parse_value(type, <<data::binary>>) do
-		{:error, Error.new(:driver, "unsupported type: #{type}", data)}
-	end
+  defp parse_value(type, <<invalid::binary>>) when type in @string_types do
+    {:error, Error.new(:driver, "invalid string prefix", invalid)}
+  end
 
-	# We don't have to do a perfect job here, just need to figure out the boundaries.
-	# The problem with :binary.split is that:
-	#  a) we want to keep the separator/terminator to keep everything consistent
-	#  b) the separator/terminator can be 2 different things
-	defp extract_token(<<data::binary>>) do
-		len = token_length(data, 0)
-		<<value::bytes-size(len), rest::binary>> = data
-		{value, rest}
-	end
-	defp token_length(<<?,, _rest::binary>>, len), do: len
-	defp token_length(<<?\t, _rest::binary>>, len), do: len
-	defp token_length(<<_, rest::binary>>, len), do: token_length(rest, len + 1)
+  defp parse_value(:uuid, <<uuid::bytes-size(36), rest::binary>>) do
+    {:ok, rest, uuid}
+  end
 
-	defp parse_string(<<data::binary>>, acc \\ []) do
-		case :binary.split(data, "\\") do
-			[text, <<?e, rest::binary>>] -> parse_string(rest, [acc, text, ?\e])
-			[text, <<?f, rest::binary>>] -> parse_string(rest, [acc, text, ?\f])
-			[text, <<?n, rest::binary>>] -> parse_string(rest, [acc, text, ?\n])
-			[text, <<?r, rest::binary>>] -> parse_string(rest, [acc, text, ?\r])
-			[text, <<?t, rest::binary>>] -> parse_string(rest, [acc, text, ?\t])
-			[text, <<?v, rest::binary>>] -> parse_string(rest, [acc, text, ?\v])
-			[text, <<?\\, rest::binary>>] -> parse_string(rest, [acc, text, ?\\])
-			[text, <<?', rest::binary>>] -> parse_string(rest, [acc, text, ?'])
-			[text, <<?", rest::binary>>] -> parse_string(rest, [acc, text, ?"])
-			[text] ->
-				# The last chunk can be terminated with either '"' or '",' depending
-				# on whether or not it's the last column. Strip it either way.
-				len1 = byte_size(text) - 1
-				len2 = len1 - 1
-				case text do
-					<<text::bytes-size(len1), ?">> -> [acc, text]
-					<<text::bytes-size(len2), ~s(",)>> -> [acc, text]
-				end
-		end
-	end
+  defp parse_value(:blob, <<data::binary>>) do
+    {value, rest} = extract_token(data)
 
-	defp build_time([hour, minute, seconds]) do
-		Time.new(hour, minute, seconds)
-	end
+    case Base.decode16(value) do
+      {:ok, value} -> {:ok, rest, value}
+      :error -> {:error, Error.new(:driver, "invalid blob", data)}
+    end
+  end
 
-	defp build_time([hour, minute, seconds, milli]) do
-		Time.new(hour, minute, seconds, {milli * 1000, 3})
-	end
+  defp parse_value(:time, <<data::binary>>) do
+    with {:ok, data, rest, _, _, _} <- extract_time(data),
+         {:ok, time} <- build_time(data) do
+      {:ok, rest, time}
+    else
+      _ -> {:error, Error.new(:driver, "invalid time", data)}
+    end
+  end
 
-	defp build_time([hour, minute, seconds, milli, micro]) do
-		Time.new(hour, minute, seconds, {milli * 1000 + micro, 6})
-	end
+  # MonetDB strips out any leading zeros from the year, so we can't use Date.from_iso8601
+  defp parse_value(:date, <<data::binary>>) do
+    with {:ok, [year, month, day], rest, _, _, _} <- extract_date(data),
+         {:ok, date} <- Date.new(year, month, day) do
+      {:ok, rest, date}
+    else
+      _ -> {:error, Error.new(:driver, "invalid date", data)}
+    end
+  end
 
-	@utc {"Etc/UTC", "UTC", 0}
-	defp build_time_zone(["z"]), do: @utc
-	defp build_time_zone(["Z"]), do: @utc
-	defp build_time_zone(["+00:00"]), do: @utc
-	defp build_time_zone(["-00:00"]), do: @utc
-	defp build_time_zone([sign, hh, mm]) do
-		time = "#{sign}#{hh}:#{mm}"
-		hours = String.to_integer(hh)
-		minutes = String.to_integer(mm)
+  defp parse_value(:timestamp, <<data::binary>>) do
+    with {:ok, <<" ", rest::binary>>, date} <- parse_value(:date, data),
+         {:ok, rest, time} <- parse_value(:time, rest),
+         {:ok, datetime} <- NaiveDateTime.new(date, time) do
+      {:ok, rest, datetime}
+    else
+      _ -> {:error, Error.new(:driver, "invalid timestamp", data)}
+    end
+  end
 
-		offset = hours * 3600 + minutes * 60
-		offset = case sign do
-			"+" -> offset
-			"-" -> -offset
-		end
+  # I'm pretty this timezone stuff isn't right
+  defp parse_value(:timestamptz, <<data::binary>>) do
+    with {:ok, <<" ", rest::binary>>, date} <- parse_value(:date, data),
+         {:ok, rest, time} <- parse_value(:time, rest),
+         {:ok, time_zone, rest, _, _, _} <- extract_time_zone(rest) do
+      {timezone, abbreviation, offset} = build_time_zone(time_zone)
 
-		{"Etc/UTC" <> time, time, offset}
-	end
+      datetime = %DateTime{
+        year: date.year,
+        month: date.month,
+        day: date.day,
+        hour: time.hour,
+        minute: time.minute,
+        second: time.second,
+        microsecond: time.microsecond,
+        utc_offset: offset,
+        # ??
+        std_offset: 0,
+        time_zone: timezone,
+        zone_abbr: abbreviation
+      }
 
-	date =
-		integer(min: 1, max: 4)
-		|> ignore(string("-"))
-		|> integer(2)
-		|> ignore(string("-"))
-		|> integer(2)
+      {:ok, rest, datetime}
+    else
+      _ -> {:error, Error.new(:driver, "invalid timestamptz", data)}
+    end
+  end
 
-	time =
-		integer(2)
-		|> ignore(string(":"))
-		|> integer(2)
-		|> ignore(string(":"))
-		|> integer(2)
-		|> optional(
-			ignore(string("."))
-			|> integer(3)
-			|> optional(integer(3))
-		)
+  defp parse_value(type, <<data::binary>>) do
+    {:error, Error.new(:driver, "unsupported type: #{type}", data)}
+  end
 
-	time_zone =
-		choice([
-			string("z"),
-			string("Z"),
-			string("+00:00"),
-			string("-00:00"),
-			string("+") |> integer(2) |> ignore(string(":")) |> integer(2),
-			string("-") |> integer(2) |> ignore(string(":")) |> integer(2)
-		])
+  # We don't have to do a perfect job here, just need to figure out the boundaries.
+  # The problem with :binary.split is that:
+  #  a) we want to keep the separator/terminator to keep everything consistent
+  #  b) the separator/terminator can be 2 different things
+  defp extract_token(<<data::binary>>) do
+    len = token_length(data, 0)
+    <<value::bytes-size(len), rest::binary>> = data
+    {value, rest}
+  end
 
-	defparsec :extract_date, date, inline: true
-	defparsec :extract_time, time, inline: true
-	defparsec :extract_time_zone, time_zone, inline: true
+  defp token_length(<<?,, _rest::binary>>, len), do: len
+  defp token_length(<<?\t, _rest::binary>>, len), do: len
+  defp token_length(<<_, rest::binary>>, len), do: token_length(rest, len + 1)
+
+  defp parse_string(<<data::binary>>, acc \\ []) do
+    case :binary.split(data, "\\") do
+      [text, <<?e, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\e])
+
+      [text, <<?f, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\f])
+
+      [text, <<?n, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\n])
+
+      [text, <<?r, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\r])
+
+      [text, <<?t, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\t])
+
+      [text, <<?v, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\v])
+
+      [text, <<?\\, rest::binary>>] ->
+        parse_string(rest, [acc, text, ?\\])
+
+      [text, <<?', rest::binary>>] ->
+        parse_string(rest, [acc, text, ?'])
+
+      [text, <<?", rest::binary>>] ->
+        parse_string(rest, [acc, text, ?"])
+
+      [text] ->
+        # The last chunk can be terminated with either '"' or '",' depending
+        # on whether or not it's the last column. Strip it either way.
+        len1 = byte_size(text) - 1
+        len2 = len1 - 1
+
+        case text do
+          <<text::bytes-size(len1), ?">> -> [acc, text]
+          <<text::bytes-size(len2), ~s(",)>> -> [acc, text]
+        end
+    end
+  end
+
+  defp build_time([hour, minute, seconds]) do
+    Time.new(hour, minute, seconds)
+  end
+
+  defp build_time([hour, minute, seconds, milli]) do
+    Time.new(hour, minute, seconds, {milli * 1000, 3})
+  end
+
+  defp build_time([hour, minute, seconds, milli, micro]) do
+    Time.new(hour, minute, seconds, {milli * 1000 + micro, 6})
+  end
+
+  @utc {"Etc/UTC", "UTC", 0}
+  defp build_time_zone(["z"]), do: @utc
+  defp build_time_zone(["Z"]), do: @utc
+  defp build_time_zone(["+00:00"]), do: @utc
+  defp build_time_zone(["-00:00"]), do: @utc
+
+  defp build_time_zone([sign, hh, mm]) do
+    time = "#{sign}#{hh}:#{mm}"
+    hours = String.to_integer(hh)
+    minutes = String.to_integer(mm)
+
+    offset = hours * 3600 + minutes * 60
+
+    offset =
+      case sign do
+        "+" -> offset
+        "-" -> -offset
+      end
+
+    {"Etc/UTC" <> time, time, offset}
+  end
+
+  date =
+    integer(min: 1, max: 4)
+    |> ignore(string("-"))
+    |> integer(2)
+    |> ignore(string("-"))
+    |> integer(2)
+
+  time =
+    integer(2)
+    |> ignore(string(":"))
+    |> integer(2)
+    |> ignore(string(":"))
+    |> integer(2)
+    |> optional(
+      ignore(string("."))
+      |> integer(3)
+      |> optional(integer(3))
+    )
+
+  time_zone =
+    choice([
+      string("z"),
+      string("Z"),
+      string("+00:00"),
+      string("-00:00"),
+      string("+") |> integer(2) |> ignore(string(":")) |> integer(2),
+      string("-") |> integer(2) |> ignore(string(":")) |> integer(2)
+    ])
+
+  defparsec(:extract_date, date, inline: true)
+  defparsec(:extract_time, time, inline: true)
+  defparsec(:extract_time_zone, time_zone, inline: true)
 end

--- a/lib/result.ex
+++ b/lib/result.ex
@@ -1,112 +1,115 @@
 defmodule Monet.Result do
-	@moduledoc """
-	Represents the result from a query to MonetDB.
+  @moduledoc """
+  Represents the result from a query to MonetDB.
 
-	For a select `columns` are the column names and `rows` is a list of lists.
-	These can be accessed directly. However, the module also implements Enumerable
-	and Jason.Encode. By default, Enumerationa and Jason.Encode will expose the list
-	of lists as-is. However, the Result can be configured to return a list of maps
-	(optionally with atom keys). See `Monet.as_map/1` and `Monet.as_map/2` for
-	more information.
+  For a select `columns` are the column names and `rows` is a list of lists.
+  These can be accessed directly. However, the module also implements Enumerable
+  and Jason.Encode. By default, Enumerationa and Jason.Encode will expose the list
+  of lists as-is. However, the Result can be configured to return a list of maps
+  (optionally with atom keys). See `Monet.as_map/1` and `Monet.as_map/2` for
+  more information.
 
-	`last_id` is non-nil in the case of an insert to a table with an auto incremental
-	column (e.g. serial) and nil in all other cases.
+  `last_id` is non-nil in the case of an insert to a table with an auto incremental
+  column (e.g. serial) and nil in all other cases.
 
-	`row_count` represents either the number of affected rows (for an update or
-	delete) or the number of `rows` (for a select).
+  `row_count` represents either the number of affected rows (for an update or
+  delete) or the number of `rows` (for a select).
 
-	Responses from the MonetDB server generally include some meta data, such as
-	timing information. This data isn't useful to this driver, but it's exposed in
-	in the `meta` field, in case it's useful to the caller. This data is unparsed;
-	it's binary field.
-	"""
-	alias __MODULE__
+  Responses from the MonetDB server generally include some meta data, such as
+  timing information. This data isn't useful to this driver, but it's exposed in
+  in the `meta` field, in case it's useful to the caller. This data is unparsed;
+  it's binary field.
+  """
+  alias __MODULE__
 
-	defstruct [
-		:mode,
-		:meta,
-		:rows,
-		:last_id,
-		:columns,
-		:row_count,
-	]
+  defstruct [
+    :mode,
+    :meta,
+    :rows,
+    :last_id,
+    :columns,
+    :row_count
+  ]
 
-	@doc """
-	Creates a new Result from a select or other queries that return data
-	"""
-	def new(header, columns, rows, count) do
-		%Result{meta: header, columns: columns, rows: rows, row_count: count}
-	end
+  @doc """
+  Creates a new Result from a select or other queries that return data
+  """
+  def new(header, columns, rows, count) do
+    %Result{meta: header, columns: columns, rows: rows, row_count: count}
+  end
 
-	@doc """
-	Creates a new Result with only a meta field (the type of result you'd get
-	from a create table, for example)
-	"""
-	def meta(meta), do: upsert(meta, 0, nil)
+  @doc """
+  Creates a new Result with only a meta field (the type of result you'd get
+  from a create table, for example)
+  """
+  def meta(meta), do: upsert(meta, 0, nil)
 
-	@doc """
-	Creates a new Result with a count and last_id, used by update/delete/insert
-	"""
-	def upsert(meta, count, last_id) do
-		%Result{meta: meta, columns: [], rows: [], row_count: count, last_id: last_id}
-	end
+  @doc """
+  Creates a new Result with a count and last_id, used by update/delete/insert
+  """
+  def upsert(meta, count, last_id) do
+    %Result{meta: meta, columns: [], rows: [], row_count: count, last_id: last_id}
+  end
 
-	@doc """
-	Switches the the mode of the result to enumerate or jason encode maps. See
-	`Monet.as_map/1` and `Monet.as_map/2` for more information.
-	"""
-	def as_map(result, opts) do
-		case Keyword.get(opts, :columns) == :atoms do
-			false -> %Result{result | mode: :map}
-			true ->
-				%Result{result |
-					mode: :map,
-					columns: Enum.map(result.columns, &String.to_atom/1)
-				}
-		end
-	end
+  @doc """
+  Switches the the mode of the result to enumerate or jason encode maps. See
+  `Monet.as_map/1` and `Monet.as_map/2` for more information.
+  """
+  def as_map(result, opts) do
+    case Keyword.get(opts, :columns) == :atoms do
+      false ->
+        %Result{result | mode: :map}
+
+      true ->
+        %Result{result | mode: :map, columns: Enum.map(result.columns, &String.to_atom/1)}
+    end
+  end
 end
 
 defimpl Enumerable, for: Monet.Result do
-	alias Monet.Result
+  alias Monet.Result
 
-	def slice(result) do
-		{:ok, result.row_count, &Enum.slice(result.rows, &1, &2)}
-	end
+  def slice(result) do
+    {:ok, result.row_count, &Enum.slice(result.rows, &1, &2)}
+  end
 
-	def count(result), do: {:ok, result.row_count}
-	def member?(_result, _value), do: {:error, __MODULE__}
+  def count(result), do: {:ok, result.row_count}
+  def member?(_result, _value), do: {:error, __MODULE__}
 
-	def reduce(_result, {:halt, acc}, _fun), do: {:halted, acc}
-	def reduce(result, {:suspend, acc}, fun), do: {:suspended, acc, &reduce(result, &1, fun)}
-	def reduce(%{rows: []}, {:cont, acc}, _fun), do: {:done, acc}
-	def reduce(result, {:cont, acc}, f) do
-		[row | rows] = result.rows
-		map = create_row(result.mode, result.columns, row)
-		reduce(%Result{result | rows: rows}, f.(map, acc), f)
-	end
+  def reduce(_result, {:halt, acc}, _fun), do: {:halted, acc}
+  def reduce(result, {:suspend, acc}, fun), do: {:suspended, acc, &reduce(result, &1, fun)}
+  def reduce(%{rows: []}, {:cont, acc}, _fun), do: {:done, acc}
 
-	@doc false
-	# exposed so that Jason.Encoder can use it
-	def create_row(:map, columns, row), do: columns |> Enum.zip(row) |> Map.new()
-	def create_row(_, _columns, row), do: row
+  def reduce(result, {:cont, acc}, f) do
+    [row | rows] = result.rows
+    map = create_row(result.mode, result.columns, row)
+    reduce(%Result{result | rows: rows}, f.(map, acc), f)
+  end
+
+  @doc false
+  # exposed so that Jason.Encoder can use it
+  def create_row(:map, columns, row), do: columns |> Enum.zip(row) |> Map.new()
+  def create_row(_, _columns, row), do: row
 end
 
 defimpl Jason.Encoder, for: Monet.Result do
-	alias Jason.Encoder
-	alias Enumerable.Monet.Result
+  alias Jason.Encoder
+  alias Enumerable.Monet.Result
 
-	def encode(%{row_count: 0}, _opts), do: "[]"
+  def encode(%{row_count: 0}, _opts), do: "[]"
 
-	def encode(result, opts) do
-		mode = result.mode
-		columns = result.columns
-		[row | rows] = result.rows
+  def encode(result, opts) do
+    mode = result.mode
+    columns = result.columns
+    [row | rows] = result.rows
 
-		first = Encoder.encode(Result.create_row(mode, columns, row), opts)
-		remainder = Enum.reduce(rows, [], fn (row, acc) ->
-			[acc, ',' , Encoder.encode(Result.create_row(mode, columns, row), opts)]
-		end)
-		['[', first, remainder, ']']
-	end
+    first = Encoder.encode(Result.create_row(mode, columns, row), opts)
+
+    remainder =
+      Enum.reduce(rows, [], fn row, acc ->
+        [acc, ',', Encoder.encode(Result.create_row(mode, columns, row), opts)]
+      end)
+
+    ['[', first, remainder, ']']
+  end
 end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -1,100 +1,100 @@
 defmodule Monet.Transaction do
-	@moduledoc """
-	Created via `Monet.transaction/1` or `Monet.transaction/2`.
-	"""
+  @moduledoc """
+  Created via `Monet.transaction/1` or `Monet.transaction/2`.
+  """
 
-	require Record
+  require Record
 
-	alias Monet.{Connection, Error, Prepared, Reader, Writer}
+  alias Monet.{Connection, Error, Prepared, Reader, Writer}
 
-	Record.defrecord(:transaction, conn: nil, ref: nil, pool_name: nil)
+  Record.defrecord(:transaction, conn: nil, ref: nil, pool_name: nil)
 
-	def new(conn) do
-		transaction(
-			conn: conn,
-			ref: make_ref(),
-			pool_name: Connection.pool_name(conn)
-		)
-	end
+  def new(conn) do
+    transaction(
+      conn: conn,
+      ref: make_ref(),
+      pool_name: Connection.pool_name(conn)
+    )
+  end
 
-	@doc """
-	Executes the query using the specific transaction
-	"""
-	def query(tx, name_or_sql, args \\ nil)
+  @doc """
+  Executes the query using the specific transaction.
+  """
+  def query(tx, name_or_sql, args \\ nil)
 
-	def query(tx, name, args) when is_atom(name) do
-		ref = transaction(tx, :ref)
-		pool_name = transaction(tx, :pool_name)
+  def query(tx, name, args) when is_atom(name) do
+    ref = transaction(tx, :ref)
+    pool_name = transaction(tx, :pool_name)
 
-		case :ets.lookup(pool_name, {ref, name}) do
-			[{_, prepared}] -> Prepared.exec(prepared, args)
-			_ -> {:error, Error.new(:driver, "unknown prepared statement", name)}
- 		end
-	end
+    case :ets.lookup(pool_name, {ref, name}) do
+      [{_, prepared}] -> Prepared.exec(prepared, args)
+      _ -> {:error, Error.new(:driver, "unknown prepared statement", name)}
+    end
+  end
 
-	def query(tx, sql, args) do
-		# Connection.query returns {result, conn} for the pool
-		# we only care about the result
-		tx
-		|> transaction(:conn)
-		|> Connection.query(sql, args)
-		|> elem(0)
-	end
+  def query(tx, sql, args) do
+    # Connection.query returns {result, conn} for the pool we only care about
+    # the result.
+    tx
+    |> transaction(:conn)
+    |> Connection.query(sql, args)
+    |> elem(0)
+  end
 
-	@doc """
-	Commits the transaction
-	"""
-	def commit(tx) do
-		conn = transaction(tx, :conn)
-		with :ok, Writer.query(conn, "commit"),
-		     {:ok, "&4 t\n"} <- Reader.message(conn) # make sure auto-commit is turned back on
-		do
-			:ok
-		else
-			{:ok, data} -> {:error, Error.new(:driver, "invalid commit response", data)}
-			err -> err
-		end
-	end
+  @doc """
+  Commits the transaction.
+  """
+  def commit(tx) do
+    conn = transaction(tx, :conn)
 
-	@doc """
-	Rollsback the transaction
-	"""
-	def rollback(tx) do
-		conn = transaction(tx, :conn)
-		with :ok, Writer.query(conn, "rollback"),
-		     {:ok, "&4 t\n"} <- Reader.message(conn)
-		do
-			:ok
-		else
-			{:ok, data} -> {:error, Error.new(:driver, "invalid rollback response", data)}
-			err -> err
-		end
-	end
+    with :ok,
+         Writer.query(conn, "commit"),
+         # make sure auto-commit is turned back on
+         {:ok, "&4 t\n"} <- Reader.message(conn) do
+      :ok
+    else
+      {:ok, data} -> {:error, Error.new(:driver, "invalid commit response", data)}
+      err -> err
+    end
+  end
 
-	@doc """
-	Prepares the statement and stores it in the transaction cache. See
-	`Monet.prepare/3`.
-	"""
-	def prepare(tx, name, sql) do
-		with {:ok, prepared} <- Prepared.new(transaction(tx, :conn), sql)
-		do
-			ref = transaction(tx, :ref)
-			pool_name = transaction(tx, :pool_name)
-			:ets.insert(pool_name, {{ref, name}, prepared})
-			:ok
-		end
-	end
+  @doc """
+  Rollsback the transaction.
+  """
+  def rollback(tx) do
+    conn = transaction(tx, :conn)
 
-	@doc """
-	Deallocates any prepared statements that were allocated as part of this
-	transaction
-	"""
-	def close(tx) do
-		ref = transaction(tx, :ref)
-		pool_name = transaction(tx, :pool_name)
-		Enum.each(:ets.match(pool_name, {{ref, :_}, :'$1'}), fn [prepared] ->
-			Prepared.close(prepared)
-		end)
-	end
+    with :ok, Writer.query(conn, "rollback"), {:ok, "&4 t\n"} <- Reader.message(conn) do
+      :ok
+    else
+      {:ok, data} -> {:error, Error.new(:driver, "invalid rollback response", data)}
+      err -> err
+    end
+  end
 
+  @doc """
+  Prepares the statement and stores it in the transaction cache. See
+  `Monet.prepare/3`.
+  """
+  def prepare(tx, name, sql) do
+    with {:ok, prepared} <- Prepared.new(transaction(tx, :conn), sql) do
+      ref = transaction(tx, :ref)
+      pool_name = transaction(tx, :pool_name)
+      :ets.insert(pool_name, {{ref, name}, prepared})
+      :ok
+    end
+  end
+
+  @doc """
+  Deallocates any prepared statements that were allocated as part of this
+  transaction.
+  """
+  def close(tx) do
+    ref = transaction(tx, :ref)
+    pool_name = transaction(tx, :pool_name)
+
+    Enum.each(:ets.match(pool_name, {{ref, :_}, :"$1"}), fn [prepared] ->
+      Prepared.close(prepared)
+    end)
+  end
 end

--- a/lib/writer.ex
+++ b/lib/writer.ex
@@ -1,96 +1,115 @@
 defmodule Monet.Writer do
-	@moduledoc """
-	Prepares and sends messages to the server. Should not be called directly from
-	outside this library.
-	"""
+  @moduledoc """
+  Prepares and sends messages to the server. Should not be called directly from
+  outside this library.
+  """
 
-	use Bitwise, only: [bsl: 2, bor: 1]
-	import Kernel, except: [send: 2]  # resolve conflict
-	import Monet.Connection, only: [connection: 2]
+  use Bitwise, only: [bsl: 2, bor: 1]
+  # resolve conflict
+  import Kernel, except: [send: 2]
+  import Monet.Connection, only: [connection: 2]
 
-	@doc """
-	Sends `data` to the server.
+  @doc """
+  Sends `data` to the server.
 
-	MonetDB only accepts individual frames up to 8190 bytes. If our message is larger
-	than this, it needs to be broken up.
+  MonetDB only accepts individual frames up to 8190 bytes. If our message is
+  larger than this, it needs to be broken up.
 
-	Each frame has a 2 byte header. 1 bit of the header is used to indicate if this
-	is the final frame of the message or not. The rest is used for the length.
-	"""
-	def send(conn, data) do
-		len = :erlang.iolist_size(data)
-		socket = connection(conn, :socket)
-		case len > 8190 do
-			true ->
-				header = <<252, 63>>  # max length not fin, aka: bor(bsl(8190, 1), 0)
-				<<data::bytes-size(8190), rest::binary>> = :erlang.iolist_to_binary(data)
-				with :ok <- do_send(socket, [header, data]) do
-					send(conn, rest)
-				end
-			false ->
-				header = <<bor(bsl(len, 1), 1)::little-16>>
-				do_send(socket, [header, data])
-		end
-	end
+  Each frame has a 2 byte header. 1 bit of the header is used to indicate if
+  this is the final frame of the message or not. The rest is used for the
+  length.
+  """
+  def send(conn, data) do
+    len = :erlang.iolist_size(data)
+    socket = connection(conn, :socket)
 
-	defp do_send(socket, data) do
-		case :gen_tcp.send(socket, data) do
-			:ok -> :ok
-			{:error, err} -> {:error, Monet.Error.new(:network, err)}
-		end
-	end
+    case len > 8190 do
+      true ->
+        # max length not fin, aka: bor(bsl(8190, 1), 0)
+        header = <<252, 63>>
+        <<data::bytes-size(8190), rest::binary>> = :erlang.iolist_to_binary(data)
 
-	@doc """
-	Sends a command to the server. Commands appear to be queries with just an empty
-	response. This should
-	"""
-	def command(conn, command) do
-		send(conn, ["X", command, "\n"])
-	end
+        with :ok <- do_send(socket, [header, data]) do
+          send(conn, rest)
+        end
 
-	@doc """
-	Sends a query to the server. Except for a very few things that are considered
-	"commands", almost everything is a query
-	"""
-	def query(conn, query) do
-		send(conn, [?s, query, ?;])
-	end
+      false ->
+        header = <<bor(bsl(len, 1), 1)::little-16>>
+        do_send(socket, [header, data])
+    end
+  end
 
-	@doc """
-	Encodes a list of value to be sent as part of a prepare + exec flow. The types
-	parameter is parsed from the response of the prepare statement. See
-	Monet.Prepared for more information
-	"""
-	def encode(values, types, acc \\ [])
-	def encode([value], [type], acc), do: [acc, encode_value(value, type)]
-	def encode([value | values], [type | types], acc), do: encode(values, types, [acc, encode_value(value, type), ?,,])
-	# should not be here, wrong number of values, let the server handle it
-	def encode(_, _, acc), do: acc
+  defp do_send(socket, data) do
+    case :gen_tcp.send(socket, data) do
+      :ok -> :ok
+      {:error, err} -> {:error, Monet.Error.new(:network, err)}
+    end
+  end
 
-	defp encode_value(nil, _type), do: "NULL"
-	defp encode_value(f, _) when is_float(f), do: Float.to_string(f)
-	defp encode_value(n, _) when is_integer(n), do: Integer.to_string(n)
-	defp encode_value(%Decimal{} = d, _), do: Decimal.to_string(d)
-	defp encode_value(true, _), do: "true"
-	defp encode_value(false, _), do: "false"
-	defp encode_value(<<data::binary>>, :blob), do: ["blob '", Base.encode16(data), ?']
-	defp encode_value(<<data::binary>>, :json), do: ["json '", encode_string(data), ?']
-	defp encode_value(<<data::binary>>, :uuid), do: ["uuid '", data, ?']
-	defp encode_value(<<data::binary>>, _), do: [?', encode_string(data), ?']
-	defp encode_value(%Time{} = t, {:time, 3}), do: ["time(3) '", Time.to_string(t), ?']
-	defp encode_value(%Time{} = t, {:time, 6}), do: ["time(6) '", Time.to_string(t), ?']
-	defp encode_value(%Time{} = t, _), do: ["time '", Time.to_string(t), ?']
-	defp encode_value(%Date{} = t, _), do: ["date '", Date.to_string(t), ?']
-	defp encode_value(%NaiveDateTime{} = t, {:time, 3}), do: ["timestamp(3) '", NaiveDateTime.to_iso8601(t), ?']
-	defp encode_value(%NaiveDateTime{} = t, {:time, 6}), do: ["timestamp(6) '", NaiveDateTime.to_iso8601(t), ?']
-	defp encode_value(%NaiveDateTime{} = t, _), do: ["timestamp '", NaiveDateTime.to_iso8601(t), ?']
-	defp encode_value(%DateTime{} = t, {:time, 3}), do: ["timestamptz(3) '", DateTime.to_iso8601(t), ?']
-	defp encode_value(%DateTime{} = t, {:time, 6}), do: ["timestamptz(6) '", DateTime.to_iso8601(t), ?']
-	defp encode_value(%DateTime{} = t, _), do: ["timestamptz '", DateTime.to_iso8601(t), ?']
+  @doc """
+  Sends a command to the server. Commands appear to be queries with just an
+  empty response. This should TODO:
+  """
+  def command(conn, command) do
+    send(conn, ["X", command, "\n"])
+  end
 
-	def encode_string(data) do
-		data
-		|> String.replace("\\", "\\\\")
-		|> String.replace("\'", "\\'")
-	end
+  @doc """
+  Sends a query to the server. Except for a very few things that are considered
+  "commands", almost everything is a query.
+  """
+  def query(conn, query) do
+    send(conn, [?s, query, ?;])
+  end
+
+  @doc """
+  Encodes a list of value to be sent as part of a prepare + exec flow. The
+  types parameter is parsed from the response of the prepare statement. See
+  Monet. TODO: Prepared for more information
+  """
+  def encode(values, types, acc \\ [])
+  def encode([value], [type], acc), do: [acc, encode_value(value, type)]
+
+  def encode([value | values], [type | types], acc),
+    do: encode(values, types, [acc, encode_value(value, type), ?,])
+
+  # should not be here, wrong number of values, let the server handle it
+  def encode(_, _, acc), do: acc
+
+  defp encode_value(nil, _type), do: "NULL"
+  defp encode_value(f, _) when is_float(f), do: Float.to_string(f)
+  defp encode_value(n, _) when is_integer(n), do: Integer.to_string(n)
+  defp encode_value(%Decimal{} = d, _), do: Decimal.to_string(d)
+  defp encode_value(true, _), do: "true"
+  defp encode_value(false, _), do: "false"
+  defp encode_value(<<data::binary>>, :blob), do: ["blob '", Base.encode16(data), ?']
+  defp encode_value(<<data::binary>>, :json), do: ["json '", encode_string(data), ?']
+  defp encode_value(<<data::binary>>, :uuid), do: ["uuid '", data, ?']
+  defp encode_value(<<data::binary>>, _), do: [?', encode_string(data), ?']
+  defp encode_value(%Time{} = t, {:time, 3}), do: ["time(3) '", Time.to_string(t), ?']
+  defp encode_value(%Time{} = t, {:time, 6}), do: ["time(6) '", Time.to_string(t), ?']
+  defp encode_value(%Time{} = t, _), do: ["time '", Time.to_string(t), ?']
+  defp encode_value(%Date{} = t, _), do: ["date '", Date.to_string(t), ?']
+
+  defp encode_value(%NaiveDateTime{} = t, {:time, 3}),
+    do: ["timestamp(3) '", NaiveDateTime.to_iso8601(t), ?']
+
+  defp encode_value(%NaiveDateTime{} = t, {:time, 6}),
+    do: ["timestamp(6) '", NaiveDateTime.to_iso8601(t), ?']
+
+  defp encode_value(%NaiveDateTime{} = t, _), do: ["timestamp '", NaiveDateTime.to_iso8601(t), ?']
+
+  defp encode_value(%DateTime{} = t, {:time, 3}),
+    do: ["timestamptz(3) '", DateTime.to_iso8601(t), ?']
+
+  defp encode_value(%DateTime{} = t, {:time, 6}),
+    do: ["timestamptz(6) '", DateTime.to_iso8601(t), ?']
+
+  defp encode_value(%DateTime{} = t, _), do: ["timestamptz '", DateTime.to_iso8601(t), ?']
+
+  def encode_string(data) do
+    data
+    |> String.replace("\\", "\\\\")
+    |> String.replace("\'", "\\'")
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,42 +1,58 @@
 defmodule Monet.MixProject do
-	use Mix.Project
+  use Mix.Project
 
-	@version "0.1.2"
+  @source_url "https://github.com/karlseguin/monet"
+  @version "0.1.2"
 
-	def project do
-		[
-			app: :monet,
-			deps: deps(),
-			elixir: "~> 1.10",
-			version: @version,
-			elixirc_paths: paths(Mix.env),
-			description: "MonetDB driver",
-			package: [
-				licenses: ["MIT"],
-				links: %{
-					"git" => "https://github.com/karlseguin/monet"
-				},
-				maintainers: ["Karl Seguin"],
-			],
-		]
-	end
+  def project do
+    [
+      app: :monet,
+      name: "Monet",
+      deps: deps(),
+      elixir: "~> 1.10",
+      version: @version,
+      elixirc_paths: paths(Mix.env()),
+      description: "MonetDB driver",
+      package: package(),
+      docs: docs()
+    ]
+  end
 
-	defp paths(:test), do: paths(:prod) ++ ["test/support"]
-	defp paths(_), do: ["lib"]
+  defp paths(:test), do: paths(:prod) ++ ["test/support"]
+  defp paths(_), do: ["lib"]
 
-	def application do
-		[
-			extra_applications: [:logger, :crypto]
-		]
-	end
+  def application do
+    [
+      extra_applications: [:logger, :crypto]
+    ]
+  end
 
-	defp deps do
-		[
-			{:jason, "~> 1.2.2"},
-			{:decimal, "~> 2.0.0"},
-			{:nimble_pool, "~> 0.2.1"},
-			{:nimble_parsec, "~> 1.1.0"},
-			{:ex_doc, "~> 0.22.6", only: :dev, runtime: false}
-		]
-	end
+  defp deps do
+    [
+      {:jason, "~> 1.2.2"},
+      {:decimal, "~> 2.0.0"},
+      {:nimble_pool, "~> 0.2.1"},
+      {:nimble_parsec, "~> 1.1.0"},
+      {:ex_doc, "~> 0.22.6", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package do
+    [
+      maintainers: ["Karl Seguin"],
+      licenses: ["ISC"],
+      links: %{"GitHub" => @source_url}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      source_url: @source_url,
+      extras: [
+        "README.md",
+        "LICENSE"
+      ]
+    ]
+  end
 end

--- a/test/auth_test.exs
+++ b/test/auth_test.exs
@@ -1,40 +1,53 @@
 defmodule Monet.Tests.Auth do
-	use Monet.Tests.Base
-	alias Monet.Auth
+  use Monet.Tests.Base
+  alias Monet.Auth
 
-	test "accepted login" do
-		conn = start_fake_server(
-			encode: "oRzY7XZr1EfNWETqU6b2:merovingian:9:RIPEMD160,SHA256,SHA1,MD5:LIT:SHA512:",
-			reply: {self(), ""}
-		)
-		assert {:ok, _} = Auth.login(conn, username: "leto", password: "atreides", database: "dune")
-		assert get_echo() == {:ok, "LIT:leto:{SHA256}9f133d2ccda31b36cb9c4a848cf4332635d353b5c8c0fee341a8c90ffcc38127:sql:dune:"}
-	end
+  test "accepted login" do
+    conn =
+      start_fake_server(
+        encode: "oRzY7XZr1EfNWETqU6b2:merovingian:9:RIPEMD160,SHA256,SHA1,MD5:LIT:SHA512:",
+        reply: {self(), ""}
+      )
 
-	test "proxy login" do
-		conn = start_fake_server(
-			encode: challenge(),
-			reply: {nil, "^mapi:merovingian://proxy?database=caladan\n"},
-			encode: "766ff6hj7:merovingian:9:RIPEMD160,SHA1,MD5:LIT:SHA256:",
-			reply: {self(), ""}
-		)
-		assert {:ok, _conn} = Auth.login(conn, username: "duncan", password: "idaho", database: "caladan")
-		assert get_echo() == {:ok, "LIT:duncan:{RIPEMD160}0570a97a0657bea37be47e8383b40a81cd78c8b4:sql:caladan:"}
-	end
+    assert {:ok, _} = Auth.login(conn, username: "leto", password: "atreides", database: "dune")
 
-	test "redirect login" do
-		conn = start_fake_server(
-			encode: challenge(),
-			reply: {nil, "^mapi:monetdb://caladan.dune.local:50001/dune_db\n"}
-		)
-		assert {:redirect, uri} = Auth.login(conn, username: "duncan", password: "idaho", database: "caladan")
-		assert uri[:port] == 50001
-		assert uri[:hostname] == "caladan.dune.local"
-		assert uri[:database] == "dune_db"
-	end
+    assert get_echo() ==
+             {:ok,
+              "LIT:leto:{SHA256}9f133d2ccda31b36cb9c4a848cf4332635d353b5c8c0fee341a8c90ffcc38127:sql:dune:"}
+  end
 
-	defp challenge() do
-		"oRzY7XZr1EfNWETqU6b2:merovingian:9:RIPEMD160,SHA256,SHA1,MD5:LIT:SHA512:"
-	end
+  test "proxy login" do
+    conn =
+      start_fake_server(
+        encode: challenge(),
+        reply: {nil, "^mapi:merovingian://proxy?database=caladan\n"},
+        encode: "766ff6hj7:merovingian:9:RIPEMD160,SHA1,MD5:LIT:SHA256:",
+        reply: {self(), ""}
+      )
 
+    assert {:ok, _conn} =
+             Auth.login(conn, username: "duncan", password: "idaho", database: "caladan")
+
+    assert get_echo() ==
+             {:ok, "LIT:duncan:{RIPEMD160}0570a97a0657bea37be47e8383b40a81cd78c8b4:sql:caladan:"}
+  end
+
+  test "redirect login" do
+    conn =
+      start_fake_server(
+        encode: challenge(),
+        reply: {nil, "^mapi:monetdb://caladan.dune.local:50001/dune_db\n"}
+      )
+
+    assert {:redirect, uri} =
+             Auth.login(conn, username: "duncan", password: "idaho", database: "caladan")
+
+    assert uri[:port] == 50001
+    assert uri[:hostname] == "caladan.dune.local"
+    assert uri[:database] == "dune_db"
+  end
+
+  defp challenge() do
+    "oRzY7XZr1EfNWETqU6b2:merovingian:9:RIPEMD160,SHA256,SHA1,MD5:LIT:SHA512:"
+  end
 end

--- a/test/monet_test.exs
+++ b/test/monet_test.exs
@@ -1,136 +1,151 @@
 defmodule Monet.Tests.Monet do
-	use Monet.Tests.Base
+  use Monet.Tests.Base
 
-	alias Monet.Tests.Generator
+  alias Monet.Tests.Generator
 
-	@sql_types [
-		char1_col: [sql: "char(1)", type: :utf8, args: 1],
-		char5_col: [sql: "char(5)", type: :utf8, args: 5],
-		char100_col: [sql: "char(100)", type: :utf8, args: 100],
-		varchar_col: [sql: "varchar(100)", type: :utf8, args: {0, 100}],
-		text_col: [sql: "text", type: :utf8, args: {0, 1000}],
-		bool_col: [sql: "bool", type: :bool],
-		tinyint_col: [sql: "tinyint", type: :int, args: 8],
-		smallint_col: [sql: "smallint", type: :int, args: 16],
-		int_col: [sql: "int", type: :int, args: 32],
-		bigint_col: [sql: "bigint", type: :int, args: 64],
-		hugeint_col: [sql: "hugeint", type: :int, args: 128],
-		double_col: [sql: "double", type: :float, args: 64],
-		decimal_col: [sql: "decimal", type: :decimal],
-		date_col: [sql: "date", type: :date],
-		time0_col: [sql: "time", type: :time],
-		time3_col: [sql: "time(3)", type: :time, args: 3],
-		time6_col: [sql: "time(6)", type: :time, args: 6],
-		blob_col: [sql: "blob", type: :blob],
-		timestamp0_col: [sql: "timestamp(0)", type: :naivedatetime],
-		timestamp3_col: [sql: "timestamp(3)", type: :naivedatetime, args: 3],
-		timestamp6_col: [sql: "timestamp(6)", type: :naivedatetime, args: 6],
-		timestamptz0_col: [sql: "timestamp(0) with time zone", type: :datetime],
-		timestamptz3_col: [sql: "timestamp(3) with time zone", type: :datetime, args: 3],
-		timestamptz6_col: [sql: "timestamp(6) with time zone", type: :datetime, args: 6],
-		json_col: [sql: "json", type: :json],
-		uuid_col: [sql: "uuid", type: :uuid]
-	]
+  @sql_types [
+    char1_col: [sql: "char(1)", type: :utf8, args: 1],
+    char5_col: [sql: "char(5)", type: :utf8, args: 5],
+    char100_col: [sql: "char(100)", type: :utf8, args: 100],
+    varchar_col: [sql: "varchar(100)", type: :utf8, args: {0, 100}],
+    text_col: [sql: "text", type: :utf8, args: {0, 1000}],
+    bool_col: [sql: "bool", type: :bool],
+    tinyint_col: [sql: "tinyint", type: :int, args: 8],
+    smallint_col: [sql: "smallint", type: :int, args: 16],
+    int_col: [sql: "int", type: :int, args: 32],
+    bigint_col: [sql: "bigint", type: :int, args: 64],
+    hugeint_col: [sql: "hugeint", type: :int, args: 128],
+    double_col: [sql: "double", type: :float, args: 64],
+    decimal_col: [sql: "decimal", type: :decimal],
+    date_col: [sql: "date", type: :date],
+    time0_col: [sql: "time", type: :time],
+    time3_col: [sql: "time(3)", type: :time, args: 3],
+    time6_col: [sql: "time(6)", type: :time, args: 6],
+    blob_col: [sql: "blob", type: :blob],
+    timestamp0_col: [sql: "timestamp(0)", type: :naivedatetime],
+    timestamp3_col: [sql: "timestamp(3)", type: :naivedatetime, args: 3],
+    timestamp6_col: [sql: "timestamp(6)", type: :naivedatetime, args: 6],
+    timestamptz0_col: [sql: "timestamp(0) with time zone", type: :datetime],
+    timestamptz3_col: [sql: "timestamp(3) with time zone", type: :datetime, args: 3],
+    timestamptz6_col: [sql: "timestamp(6) with time zone", type: :datetime, args: 6],
+    json_col: [sql: "json", type: :json],
+    uuid_col: [sql: "uuid", type: :uuid]
+  ]
 
-	setup_all do
-		connect()
-		:ok
-	end
+  setup_all do
+    connect()
+    :ok
+  end
 
-	test "deallocates prepared" do
-		Monet.query!("select 1 - ?, 'a'", [1])
-		assert Monet.query!("select 1 from sys.prepared_statements").row_count == 0
+  test "deallocates prepared" do
+    Monet.query!("select 1 - ?, 'a'", [1])
+    assert Monet.query!("select 1 from sys.prepared_statements").row_count == 0
 
-		# even on error
-		assert {:error, _} = Monet.query("select 1 - ?", ["a'"])
-		assert Monet.query!("select * from sys.prepared_statements").row_count == 0
-	end
+    # even on error
+    assert {:error, _} = Monet.query("select 1 - ?", ["a'"])
+    assert Monet.query!("select * from sys.prepared_statements").row_count == 0
+  end
 
-	test "result with no rows" do
-		result = Monet.query!("select 1 where false")
-		assert result.rows == []
-		assert result.row_count == 0
-		assert Enum.count(result) == 0
-	end
+  test "result with no rows" do
+    result = Monet.query!("select 1 where false")
+    assert result.rows == []
+    assert result.row_count == 0
+    assert Enum.count(result) == 0
+  end
 
-	test "json escapes" do
-		Monet.query!("drop table if exists sql_types")
-		Monet.query!("create table sql_types (id serial, j json)")
+  test "json escapes" do
+    Monet.query!("drop table if exists sql_types")
+    Monet.query!("create table sql_types (id serial, j json)")
 
-		t = fn m->
-			json = Jason.encode!(m)
-			Monet.query!("insert into sql_types (j) values (?)", [json])
-			[actual] = Monet.query!("select j from sql_types order by id desc limit 1").rows
-			assert Jason.decode!(actual, keys: :atoms) == m
-		end
+    t = fn m ->
+      json = Jason.encode!(m)
+      Monet.query!("insert into sql_types (j) values (?)", [json])
+      [actual] = Monet.query!("select j from sql_types order by id desc limit 1").rows
+      assert Jason.decode!(actual, keys: :atoms) == m
+    end
 
-		t.(%{name: "\\"})
-		t.(%{name: "\'"})
-		t.(%{name: "\'\t\\\""})
-	end
+    t.(%{name: "\\"})
+    t.(%{name: "\'"})
+    t.(%{name: "\'\t\\\""})
+  end
 
-	test "fuzz insert and select sql types" do
-		create = @sql_types
-		|> Enum.map(fn {name, opts}	 -> "#{name} #{opts[:sql]} null" end)
-		|> Enum.join(", ")
+  test "fuzz insert and select sql types" do
+    create =
+      @sql_types
+      |> Enum.map(fn {name, opts} -> "#{name} #{opts[:sql]} null" end)
+      |> Enum.join(", ")
 
-		columns = @sql_types
-		|> Enum.map(fn {name, _} -> name end)
-		|> Enum.reverse() # so we don't have to reverse the inputs/outputs on each iteration
-		|> Enum.join(", ")
+    columns =
+      @sql_types
+      |> Enum.map(fn {name, _} -> name end)
+      # so we don't have to reverse the inputs/outputs on each iteration
+      |> Enum.reverse()
+      |> Enum.join(", ")
 
-		placeholders = 1..length(@sql_types)
-		|> Enum.map(fn _ -> "?" end)
-		|> Enum.join(", ")
+    placeholders =
+      1..length(@sql_types)
+      |> Enum.map(fn _ -> "?" end)
+      |> Enum.join(", ")
 
-		concurrency = 1..4
+    concurrency = 1..4
 
-		# MonetDB doesn't like concurrent DDL statements, so do this serially
-		Enum.each(concurrency, fn i ->
-			Monet.query!("drop table if exists sql_types_#{i}")
-			Monet.query!("create table sql_types_#{i} (id serial, #{create})")
-		end)
+    # MonetDB doesn't like concurrent DDL statements, so do this serially
+    Enum.each(concurrency, fn i ->
+      Monet.query!("drop table if exists sql_types_#{i}")
+      Monet.query!("create table sql_types_#{i} (id serial, #{create})")
+    end)
 
-		fuzz = fn i ->
-			insert = "insert into sql_types_#{i} (#{columns}) values (#{placeholders})"
-			value_configs = Keyword.values(@sql_types)
-			for _ <- 1..200 do
-				{inputs, outputs} = Enum.reduce(value_configs, {[], []}, fn config, {inputs, outputs} ->
-					{i, o} = case generate(config[:type], config[:args]) do
-						{i, o} -> {i, o}
-						value -> {value, value}
-					end
-					{[i | inputs], [o | outputs]}
-				end)
-				assert Monet.query!(insert, inputs).row_count == 1
-				[row] = Monet.query!("select #{columns} from sql_types_#{i} order by id desc limit 1").rows
-				assert row == outputs
-			end
-		end
+    fuzz = fn i ->
+      insert = "insert into sql_types_#{i} (#{columns}) values (#{placeholders})"
+      value_configs = Keyword.values(@sql_types)
 
-		concurrency
-		|> Enum.map(fn i -> Task.async(fn -> fuzz.(i) end) end)
-		|> Enum.map(fn t -> Task.await(t, :infinity) end)
-	end
+      for _ <- 1..200 do
+        {inputs, outputs} =
+          Enum.reduce(value_configs, {[], []}, fn config, {inputs, outputs} ->
+            {i, o} =
+              case generate(config[:type], config[:args]) do
+                {i, o} -> {i, o}
+                value -> {value, value}
+              end
 
-	defp generate(:utf8, {min, max}), do: nil_or(fn -> Generator.utf8(min, max) end)
-	defp generate(:utf8, len), do: nil_or(fn -> Generator.utf8(len, len) end)
-	defp generate(:int, power), do: nil_or(fn -> Generator.int(power) end)
-	defp generate(:bool, _), do: nil_or(fn -> Generator.bool() end)
-	defp generate(:float, power), do: nil_or(fn -> Generator.float(power) end)
-	defp generate(:decimal, _), do: nil_or(fn -> Generator.decimal() end)
-	defp generate(:date, _), do: nil_or(fn -> Generator.date() end)
-	defp generate(:time, precision), do: nil_or(fn -> Generator.time(precision) end)
-	defp generate(:blob, _), do: nil_or(fn -> Generator.blob() end)
-	defp generate(:datetime, precision), do: nil_or(fn -> Generator.datetime(precision) end)
-	defp generate(:naivedatetime, precision), do: nil_or(fn -> Generator.naivedatetime(precision) end)
-	defp generate(:json, _), do: nil_or(fn -> Generator.json() end)
-	defp generate(:uuid, _), do: nil_or(fn -> Generator.uuid() end)
+            {[i | inputs], [o | outputs]}
+          end)
 
-	defp nil_or(fun) do
-		case :rand.uniform(10) == 10 do
-			true -> nil
-			false -> fun.()
-		end
-	end
+        assert Monet.query!(insert, inputs).row_count == 1
+
+        [row] =
+          Monet.query!("select #{columns} from sql_types_#{i} order by id desc limit 1").rows
+
+        assert row == outputs
+      end
+    end
+
+    concurrency
+    |> Enum.map(fn i -> Task.async(fn -> fuzz.(i) end) end)
+    |> Enum.map(fn t -> Task.await(t, :infinity) end)
+  end
+
+  defp generate(:utf8, {min, max}), do: nil_or(fn -> Generator.utf8(min, max) end)
+  defp generate(:utf8, len), do: nil_or(fn -> Generator.utf8(len, len) end)
+  defp generate(:int, power), do: nil_or(fn -> Generator.int(power) end)
+  defp generate(:bool, _), do: nil_or(fn -> Generator.bool() end)
+  defp generate(:float, power), do: nil_or(fn -> Generator.float(power) end)
+  defp generate(:decimal, _), do: nil_or(fn -> Generator.decimal() end)
+  defp generate(:date, _), do: nil_or(fn -> Generator.date() end)
+  defp generate(:time, precision), do: nil_or(fn -> Generator.time(precision) end)
+  defp generate(:blob, _), do: nil_or(fn -> Generator.blob() end)
+  defp generate(:datetime, precision), do: nil_or(fn -> Generator.datetime(precision) end)
+
+  defp generate(:naivedatetime, precision),
+    do: nil_or(fn -> Generator.naivedatetime(precision) end)
+
+  defp generate(:json, _), do: nil_or(fn -> Generator.json() end)
+  defp generate(:uuid, _), do: nil_or(fn -> Generator.uuid() end)
+
+  defp nil_or(fun) do
+    case :rand.uniform(10) == 10 do
+      true -> nil
+      false -> fun.()
+    end
+  end
 end

--- a/test/query/select_test.exs
+++ b/test/query/select_test.exs
@@ -1,183 +1,212 @@
 defmodule Monet.Tests.Query.Select do
-	use Monet.Tests.Base
+  use Monet.Tests.Base
 
-	use Monet.Query.Select
+  use Monet.Query.Select
 
-	test "basic select" do
-		{sql, []} = Select.new()
-		|> Select.from("table")
-		|> render()
+  test "basic select" do
+    {sql, []} =
+      Select.new()
+      |> Select.from("table")
+      |> render()
 
-		assert sql == "select * from table"
-	end
+    assert sql == "select * from table"
+  end
 
-	test "select with columns" do
-		{sql, []} = Select.new()
-		|> Select.columns("id")
-		|> Select.from("table")
-		|> render()
+  test "select with columns" do
+    {sql, []} =
+      Select.new()
+      |> Select.columns("id")
+      |> Select.from("table")
+      |> render()
 
-		assert sql == "select id from table"
-	end
+    assert sql == "select id from table"
+  end
 
-	test "select with columns (2)" do
-		{sql, []} = Select.new()
-		|> Select.columns("id")
-		|> Select.columns("name")
-		|> Select.columns(~w(created updated))
-		|> Select.from("table")
-		|> render()
+  test "select with columns (2)" do
+    {sql, []} =
+      Select.new()
+      |> Select.columns("id")
+      |> Select.columns("name")
+      |> Select.columns(~w(created updated))
+      |> Select.from("table")
+      |> render()
 
-		assert sql == "select id, name, created, updated from table"
-	end
+    assert sql == "select id, name, created, updated from table"
+  end
 
-	test "joins" do
-		{sql, []} = Select.new()
-		|> Select.from("ta a")
-		|> Select.join("tb b on a.id = b.a_id")
-		|> Select.join(:left, "tc c on a.id = c.a_id")
-		|> Select.join(:right, "td d on a.id = d.a_id")
-		|> Select.join(:full, "te e on a.id = e.a_id")
-		|> render()
+  test "joins" do
+    {sql, []} =
+      Select.new()
+      |> Select.from("ta a")
+      |> Select.join("tb b on a.id = b.a_id")
+      |> Select.join(:left, "tc c on a.id = c.a_id")
+      |> Select.join(:right, "td d on a.id = d.a_id")
+      |> Select.join(:full, "te e on a.id = e.a_id")
+      |> render()
 
-		assert sql == "select * from ta a join tb b on a.id = b.a_id left join tc c on a.id = c.a_id right join td d on a.id = d.a_id full join te e on a.id = e.a_id"
-	end
+    assert sql ==
+             "select * from ta a join tb b on a.id = b.a_id left join tc c on a.id = c.a_id right join td d on a.id = d.a_id full join te e on a.id = e.a_id"
+  end
 
-	test "order" do
-		base = Select.from(Select.new(), "t")
+  test "order" do
+    base = Select.from(Select.new(), "t")
 
-		{sql, []} = base |> Select.order("x") |> render()
-		assert sql == "select * from t order by x"
+    {sql, []} = base |> Select.order("x") |> render()
+    assert sql == "select * from t order by x"
 
-		{sql, []} = base |> Select.order("x", true) |> render()
-		assert sql == "select * from t order by x"
+    {sql, []} = base |> Select.order("x", true) |> render()
+    assert sql == "select * from t order by x"
 
-		{sql, []} = base |> Select.order("x", false) |> render()
-		assert sql == "select * from t order by x desc"
+    {sql, []} = base |> Select.order("x", false) |> render()
+    assert sql == "select * from t order by x desc"
 
-		{sql, []} = base |> Select.order("x", false) |> Select.order("y") |> render()
-		assert sql == "select * from t order by x desc, y"
-	end
+    {sql, []} = base |> Select.order("x", false) |> Select.order("y") |> render()
+    assert sql == "select * from t order by x desc, y"
+  end
 
-	test "limit / offset" do
-		base = Select.from(Select.new(), "t")
+  test "limit / offset" do
+    base = Select.from(Select.new(), "t")
 
-		{sql, []} = base |> Select.limit(10) |> render()
-		assert sql == "select * from t limit 10"
+    {sql, []} = base |> Select.limit(10) |> render()
+    assert sql == "select * from t limit 10"
 
-		{sql, []} = base |> Select.offset(20) |> render()
-		assert sql == "select * from t offset 20"
+    {sql, []} = base |> Select.offset(20) |> render()
+    assert sql == "select * from t offset 20"
 
-		{sql, []} = base |> Select.limit(20) |> Select.offset(40) |> render()
-		assert sql == "select * from t limit 20 offset 40"
-	end
+    {sql, []} = base |> Select.limit(20) |> Select.offset(40) |> render()
+    assert sql == "select * from t limit 20 offset 40"
+  end
 
-	test "order+group+limit+offset" do
-		{sql, []} = Select.new()
-		|> Select.from("t")
-		|> Select.order("x")
-		|> Select.order("y", false)
-		|> Select.group("name")
-		|> Select.offset(1000)
-		|> Select.limit(100)
-		|> render()
+  test "order+group+limit+offset" do
+    {sql, []} =
+      Select.new()
+      |> Select.from("t")
+      |> Select.order("x")
+      |> Select.order("y", false)
+      |> Select.group("name")
+      |> Select.offset(1000)
+      |> Select.limit(100)
+      |> render()
 
-		assert sql == "select * from t group by name order by x, y desc limit 100 offset 1000"
-	end
+    assert sql == "select * from t group by name order by x, y desc limit 100 offset 1000"
+  end
 
+  test "simple filters" do
+    {sql, args} =
+      Select.new()
+      |> Select.from("t")
+      |> Select.where("a1", :eq, 1)
+      |> Select.where("a2", :eq, :atom)
+      |> Select.where("a3", :eq, true)
+      |> Select.where("a4", :eq, "over")
+      |> Select.where("a5", :eq, nil)
+      |> Select.where("b1", :ne, 9000)
+      |> Select.where("b2", :ne, :atom)
+      |> Select.where("b3", :ne, false)
+      |> Select.where("b4", :ne, "dune")
+      |> Select.where("b5", :ne, nil)
+      |> Select.where("c1", :gt, 10)
+      |> Select.where("c2", :gte, 11)
+      |> Select.where("d1", :lt, 12)
+      |> Select.where("d2", :lte, 13)
+      |> render()
 
-	test "simple filters" do
-		{sql, args} = Select.new()
-		|> Select.from("t")
-		|> Select.where("a1", :eq, 1)
-		|> Select.where("a2", :eq, :atom)
-		|> Select.where("a3", :eq, true)
-		|> Select.where("a4", :eq, "over")
-		|> Select.where("a5", :eq, nil)
-		|> Select.where("b1", :ne, 9000)
-		|> Select.where("b2", :ne, :atom)
-		|> Select.where("b3", :ne, false)
-		|> Select.where("b4", :ne, "dune")
-		|> Select.where("b5", :ne, nil)
-		|> Select.where("c1", :gt, 10)
-		|> Select.where("c2", :gte, 11)
-		|> Select.where("d1", :lt, 12)
-		|> Select.where("d2", :lte, 13)
-		|> render()
-
-		assert sql == flatten("select * from t
+    assert sql == flatten("select * from t
 			where a1 = ? and a2 = ? and a3 = ? and a4 = ? and a5 is null
 			and b1 != ? and b2 != ? and b3 != ? and b4 != ? and b5 is not null
 			and c1 > ? and c2 >= ? and d1 < ? and d2 <= ?")
 
-		assert args == [
-			1, "atom", true, "over",
-			9000, "atom", false, "dune",
-			10, 11, 12, 13
-		]
-	end
+    assert args == [
+             1,
+             "atom",
+             true,
+             "over",
+             9000,
+             "atom",
+             false,
+             "dune",
+             10,
+             11,
+             12,
+             13
+           ]
+  end
 
-	test "null filters" do
-		{sql, args} = Select.new()
-		|> Select.from("t")
-		|> Select.where_ignore_nil("a1", :eq, 1)
-		|> Select.where_ignore_nil("a2", :eq, :atom)
-		|> Select.where_ignore_nil("a3", :eq, true)
-		|> Select.where_ignore_nil("a4", :eq, "over")
-		|> Select.where_ignore_nil("a5", :eq, nil)
-		|> Select.where_ignore_nil("b1", :ne, 9000)
-		|> Select.where_ignore_nil("b2", :ne, :atom)
-		|> Select.where_ignore_nil("b3", :ne, false)
-		|> Select.where_ignore_nil("b4", :ne, "dune")
-		|> Select.where_ignore_nil("b5", :ne, nil)
-		|> Select.where_ignore_nil("c1", :gt, 10)
-		|> Select.where_ignore_nil("c2", :gte, 11)
-		|> Select.where_ignore_nil("d1", :lt, 12)
-		|> Select.where_ignore_nil("d2", :lte, 13)
-		|> render()
+  test "null filters" do
+    {sql, args} =
+      Select.new()
+      |> Select.from("t")
+      |> Select.where_ignore_nil("a1", :eq, 1)
+      |> Select.where_ignore_nil("a2", :eq, :atom)
+      |> Select.where_ignore_nil("a3", :eq, true)
+      |> Select.where_ignore_nil("a4", :eq, "over")
+      |> Select.where_ignore_nil("a5", :eq, nil)
+      |> Select.where_ignore_nil("b1", :ne, 9000)
+      |> Select.where_ignore_nil("b2", :ne, :atom)
+      |> Select.where_ignore_nil("b3", :ne, false)
+      |> Select.where_ignore_nil("b4", :ne, "dune")
+      |> Select.where_ignore_nil("b5", :ne, nil)
+      |> Select.where_ignore_nil("c1", :gt, 10)
+      |> Select.where_ignore_nil("c2", :gte, 11)
+      |> Select.where_ignore_nil("d1", :lt, 12)
+      |> Select.where_ignore_nil("d2", :lte, 13)
+      |> render()
 
-		assert sql == flatten("select * from t
+    assert sql == flatten("select * from t
 			where a1 = ? and a2 = ? and a3 = ? and a4 = ?
 			and b1 != ? and b2 != ? and b3 != ? and b4 != ?
 			and c1 > ? and c2 >= ? and d1 < ? and d2 <= ?")
 
-		assert args == [
-			1, "atom", true, "over",
-			9000, "atom", false, "dune",
-			10, 11, 12, 13
-		]
-	end
+    assert args == [
+             1,
+             "atom",
+             true,
+             "over",
+             9000,
+             "atom",
+             false,
+             "dune",
+             10,
+             11,
+             12,
+             13
+           ]
+  end
 
-	test "where group" do
-		{sql, args} = Select.new()
-		|> Select.from("t")
-		|> Select.where_or(fn w -> w |> eq("name", "goku") |> gt("power", 9000) end)
-		|> Select.where("a", :eq, true)
-		|> render()
+  test "where group" do
+    {sql, args} =
+      Select.new()
+      |> Select.from("t")
+      |> Select.where_or(fn w -> w |> eq("name", "goku") |> gt("power", 9000) end)
+      |> Select.where("a", :eq, true)
+      |> render()
 
-		assert sql == "select * from t where (name = ? or power > ?)  and a = ?"
-		assert args == ["goku", 9000, true]
-	end
+    assert sql == "select * from t where (name = ? or power > ?)  and a = ?"
+    assert args == ["goku", 9000, true]
+  end
 
-	test "exec" do
-		connect()
-		assert Select.new()
-		|> Select.columns("1")
-		|> Select.from("sys.tables")
-		|> Select.where("1", :eq, 1)
-		|> Select.limit(1)
-		|> Select.exec!()
-		|> Monet.scalar!() == 1
-	end
+  test "exec" do
+    connect()
 
-	defp render(select) do
-		{sql, args} = Select.to_sql(select)
+    assert Select.new()
+           |> Select.columns("1")
+           |> Select.from("sys.tables")
+           |> Select.where("1", :eq, 1)
+           |> Select.limit(1)
+           |> Select.exec!()
+           |> Monet.scalar!() == 1
+  end
 
-		sql = sql
-		|> :erlang.iolist_to_binary()
-		|> String.trim()
-		{sql, args}
-	end
+  defp render(select) do
+    {sql, args} = Select.to_sql(select)
 
-	defp flatten(sql), do: String.replace(sql, ~r/\s+/, " ")
+    sql =
+      sql
+      |> :erlang.iolist_to_binary()
+      |> String.trim()
+
+    {sql, args}
+  end
+
+  defp flatten(sql), do: String.replace(sql, ~r/\s+/, " ")
 end

--- a/test/reader_test.exs
+++ b/test/reader_test.exs
@@ -1,39 +1,45 @@
 defmodule Monet.Tests.Reader do
-	use Monet.Tests.Base
-	alias Monet.Reader
+  use Monet.Tests.Base
+  alias Monet.Reader
 
-	test "prompt (an empty message)" do
-		conn = start_fake_server(say: <<1, 0>>)
-		assert Reader.message(conn) == {:ok, ""}
-	end
+  test "prompt (an empty message)" do
+    conn = start_fake_server(say: <<1, 0>>)
+    assert Reader.message(conn) == {:ok, ""}
+  end
 
-	test "single frame message" do
-		conn = start_fake_server(say: <<9, 0, ?d, ?u, ?n, ?e>>)
-		assert Reader.message(conn) == {:ok, "dune"}
-	end
+  test "single frame message" do
+    conn = start_fake_server(say: <<9, 0, ?d, ?u, ?n, ?e>>)
+    assert Reader.message(conn) == {:ok, "dune"}
+  end
 
-	test "multi frame message" do
-		conn = start_fake_server(say: <<8, 0, ?o, ?v, ?e, ?r>>, say: <<11, 0, ?9, ?0, ?0, ?0, ?!>>)
-		assert Reader.message(conn) == {:ok, "over9000!"}
-	end
+  test "multi frame message" do
+    conn = start_fake_server(say: <<8, 0, ?o, ?v, ?e, ?r>>, say: <<11, 0, ?9, ?0, ?0, ?0, ?!>>)
+    assert Reader.message(conn) == {:ok, "over9000!"}
+  end
 
-	test "returns server error" do
-		conn = start_fake_server(say: <<18, 0, ?!, ?7, ?0, ?0, ?1, ?!, ?n, ?o, ?\n>>)
-		assert Reader.message(conn) == {:error, %Monet.Error{code: 7001, message: "no\n", source: :monetd}}
-	end
+  test "returns server error" do
+    conn = start_fake_server(say: <<18, 0, ?!, ?7, ?0, ?0, ?1, ?!, ?n, ?o, ?\n>>)
 
-	test "returns network error" do
-		conn = start_fake_server(close: true)
-		assert Reader.message(conn) == {:error, %Monet.Error{details: nil, message: :closed, source: :network}}
-	end
+    assert Reader.message(conn) ==
+             {:error, %Monet.Error{code: 7001, message: "no\n", source: :monetd}}
+  end
 
-	# These are weird MonetDB errors. I thought all errors just started with !, but
-	# nope, some look like a normal result, but actually turn out to be an error.
-	# I can't figure out how to reliably cause these, so we have to fake the payload
-	test "handles create error" do
-		conn = start_fake_server(say: <<29, 0, ?&, ?3, ?\s, ?7, ?2, ?\n, ?!, ?2, ?0, ?1, ?!, ?e, ?r, ?1>>)
-		assert {:error, err} = Reader.result(conn)
-		assert err.code == 201
-		assert err.message == "er1"
-	end
+  test "returns network error" do
+    conn = start_fake_server(close: true)
+
+    assert Reader.message(conn) ==
+             {:error, %Monet.Error{details: nil, message: :closed, source: :network}}
+  end
+
+  # These are weird MonetDB errors. I thought all errors just started with !, but
+  # nope, some look like a normal result, but actually turn out to be an error.
+  # I can't figure out how to reliably cause these, so we have to fake the payload
+  test "handles create error" do
+    conn =
+      start_fake_server(say: <<29, 0, ?&, ?3, ?\s, ?7, ?2, ?\n, ?!, ?2, ?0, ?1, ?!, ?e, ?r, ?1>>)
+
+    assert {:error, err} = Reader.result(conn)
+    assert err.code == 201
+    assert err.message == "er1"
+  end
 end

--- a/test/result_test.exs
+++ b/test/result_test.exs
@@ -1,160 +1,246 @@
 defmodule Monet.Tests.Result do
-	use Monet.Tests.Base
+  use Monet.Tests.Base
 
-	setup_all do
-		connect()
+  setup_all do
+    connect()
 
-		Monet.query!("drop table if exists result_test")
-		Monet.query!("create table result_test (id int, name text)")
+    Monet.query!("drop table if exists result_test")
+    Monet.query!("create table result_test (id int, name text)")
 
-		Monet.query!("
+    Monet.query!(
+      "
 			insert into result_test
 			values (?, ?), (?, ?), (?, ?)
-		", [1, "Leto", 2, "Jessica", 3, "Paul"])
+		",
+      [1, "Leto", 2, "Jessica", 3, "Paul"]
+    )
 
-		:ok
-	end
+    :ok
+  end
 
-	test "enumerates a list of lists" do
-		result = "select * from result_test order by id"
-		|> Monet.query!()
-		|> Enum.map(fn [id, name] -> [name, id] end)
+  test "enumerates a list of lists" do
+    result =
+      "select * from result_test order by id"
+      |> Monet.query!()
+      |> Enum.map(fn [id, name] -> [name, id] end)
 
-		assert result == [
-			["Leto", 1], ["Jessica", 2], ["Paul", 3],
-		]
-	end
+    assert result == [
+             ["Leto", 1],
+             ["Jessica", 2],
+             ["Paul", 3]
+           ]
+  end
 
-	test "jason encodes list of lists" do
-		result = "select * from result_test order by id"
-		|> Monet.query!()
-		|> Jason.encode!()
-		|> Jason.decode!()
+  test "jason encodes list of lists" do
+    result =
+      "select * from result_test order by id"
+      |> Monet.query!()
+      |> Jason.encode!()
+      |> Jason.decode!()
 
-		assert result == [
-			[1, "Leto"], [2, "Jessica"], [3, "Paul"],
-		]
-	end
+    assert result == [
+             [1, "Leto"],
+             [2, "Jessica"],
+             [3, "Paul"]
+           ]
+  end
 
-	test "enumerates a list of maps" do
-		result = "select * from result_test order by id"
-		|> Monet.query!()
-		|> Monet.as_map()
-		|> Enum.to_list()
+  test "enumerates a list of maps" do
+    result =
+      "select * from result_test order by id"
+      |> Monet.query!()
+      |> Monet.as_map()
+      |> Enum.to_list()
 
-		assert result == [
-			%{"id" => 1, "name" => "Leto"},
-			%{"id" => 2, "name" => "Jessica"},
-			%{"id" => 3, "name" => "Paul"}
-		]
-	end
+    assert result == [
+             %{"id" => 1, "name" => "Leto"},
+             %{"id" => 2, "name" => "Jessica"},
+             %{"id" => 3, "name" => "Paul"}
+           ]
+  end
 
-	test "json encodes a list of maps" do
-		result = "select * from result_test order by id"
-		|> Monet.query!()
-		|> Monet.as_map()
-		|> Jason.encode!()
-		|> Jason.decode!()
+  test "json encodes a list of maps" do
+    result =
+      "select * from result_test order by id"
+      |> Monet.query!()
+      |> Monet.as_map()
+      |> Jason.encode!()
+      |> Jason.decode!()
 
-		assert result == [
-			%{"id" => 1, "name" => "Leto"},
-			%{"id" => 2, "name" => "Jessica"},
-			%{"id" => 3, "name" => "Paul"}
-		]
-	end
+    assert result == [
+             %{"id" => 1, "name" => "Leto"},
+             %{"id" => 2, "name" => "Jessica"},
+             %{"id" => 3, "name" => "Paul"}
+           ]
+  end
 
-	test "enumerates a list of maps with atom columns" do
-		result = "select * from result_test order by id"
-		|> Monet.query!()
-		|> Monet.as_map(columns: :atoms)
-		|> Enum.to_list()
+  test "enumerates a list of maps with atom columns" do
+    result =
+      "select * from result_test order by id"
+      |> Monet.query!()
+      |> Monet.as_map(columns: :atoms)
+      |> Enum.to_list()
 
-		assert result == [
-			%{id: 1, name: "Leto"},
-			%{id: 2, name: "Jessica"},
-			%{id: 3, name: "Paul"}
-		]
-	end
+    assert result == [
+             %{id: 1, name: "Leto"},
+             %{id: 2, name: "Jessica"},
+             %{id: 3, name: "Paul"}
+           ]
+  end
 
-	test "rows helper" do
-		result = Monet.query!("select 1, 2")
-		assert Monet.rows(result) == {:ok, [[1, 2]]}
-		assert Monet.rows({:ok, result}) == {:ok, [[1, 2]]}
-		assert Monet.rows!(result) == [[1, 2]]
-		assert Monet.rows!({:ok, result}) == [[1, 2]]
+  test "rows helper" do
+    result = Monet.query!("select 1, 2")
+    assert Monet.rows(result) == {:ok, [[1, 2]]}
+    assert Monet.rows({:ok, result}) == {:ok, [[1, 2]]}
+    assert Monet.rows!(result) == [[1, 2]]
+    assert Monet.rows!({:ok, result}) == [[1, 2]]
 
-		result = Monet.query!("select 1, 2 union all select 3, 4")
-		assert Monet.rows(result) == {:ok, [[1, 2], [3, 4]]}
-		assert Monet.rows({:ok, result}) == {:ok, [[1, 2], [3, 4]]}
-		assert Monet.rows!(result) == [[1, 2], [3, 4]]
-		assert Monet.rows!({:ok, result}) == [[1, 2], [3, 4]]
+    result = Monet.query!("select 1, 2 union all select 3, 4")
+    assert Monet.rows(result) == {:ok, [[1, 2], [3, 4]]}
+    assert Monet.rows({:ok, result}) == {:ok, [[1, 2], [3, 4]]}
+    assert Monet.rows!(result) == [[1, 2], [3, 4]]
+    assert Monet.rows!({:ok, result}) == [[1, 2], [3, 4]]
 
-		assert Monet.rows(Monet.query!("select 1 where false")) == {:ok, []}
-	end
+    assert Monet.rows(Monet.query!("select 1 where false")) == {:ok, []}
+  end
 
-	test "row helper" do
-		result = Monet.query!("select 1, 2")
-		assert Monet.row(result) == {:ok, [1, 2]}
-		assert Monet.row({:ok, result}) == {:ok, [1, 2]}
-		assert Monet.row!(result) == [1, 2]
-		assert Monet.row!({:ok, result}) == [1, 2]
+  test "row helper" do
+    result = Monet.query!("select 1, 2")
+    assert Monet.row(result) == {:ok, [1, 2]}
+    assert Monet.row({:ok, result}) == {:ok, [1, 2]}
+    assert Monet.row!(result) == [1, 2]
+    assert Monet.row!({:ok, result}) == [1, 2]
 
-		result = Monet.query!("select 1 where false")
-		assert Monet.row(result) == {:ok, nil}
-		assert Monet.row!({:ok, result}) == nil
+    result = Monet.query!("select 1 where false")
+    assert Monet.row(result) == {:ok, nil}
+    assert Monet.row!({:ok, result}) == nil
 
-		result = Monet.query!("select 1, 2 union all select 3, 4")
-		assert Monet.row(result) == {:error, %Monet.Error{code: nil, details: nil, message: "row called but multiple rows returned", source: :client}}
-		assert Monet.row({:ok, result}) == {:error, %Monet.Error{code: nil, details: nil, message: "row called but multiple rows returned", source: :client}}
+    result = Monet.query!("select 1, 2 union all select 3, 4")
 
-		assert_raise Monet.Error, "client row called but multiple rows returned", fn -> Monet.row!(result) end
-	end
+    assert Monet.row(result) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "row called but multiple rows returned",
+                source: :client
+              }}
 
-	test "map helper" do
-		result = Monet.query!("select 1 a, 2 b")
-		assert Monet.map(result) == {:ok, %{"a" => 1, "b" => 2}}
-		assert Monet.map({:ok, result}, columns: :atoms) == {:ok, %{a: 1, b: 2}}
-		assert Monet.map!(result, columns: :atoms) == %{a: 1, b: 2}
-		assert Monet.map!({:ok, result}) == %{"a" => 1, "b" => 2}
+    assert Monet.row({:ok, result}) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "row called but multiple rows returned",
+                source: :client
+              }}
 
-		result = Monet.query!("select 1 where false")
-		assert Monet.map(result) == {:ok, nil}
-		assert Monet.map!({:ok, result}) == nil
+    assert_raise Monet.Error, "client row called but multiple rows returned", fn ->
+      Monet.row!(result)
+    end
+  end
 
-		result = Monet.query!("select 1, 2 union all select 3, 4")
-		assert Monet.map(result) == {:error, %Monet.Error{code: nil, details: nil, message: "map called but multiple rows returned", source: :client}}
-		assert Monet.map({:ok, result}) == {:error, %Monet.Error{code: nil, details: nil, message: "map called but multiple rows returned", source: :client}}
+  test "map helper" do
+    result = Monet.query!("select 1 a, 2 b")
+    assert Monet.map(result) == {:ok, %{"a" => 1, "b" => 2}}
+    assert Monet.map({:ok, result}, columns: :atoms) == {:ok, %{a: 1, b: 2}}
+    assert Monet.map!(result, columns: :atoms) == %{a: 1, b: 2}
+    assert Monet.map!({:ok, result}) == %{"a" => 1, "b" => 2}
 
-		assert_raise Monet.Error, "client map called but multiple rows returned", fn -> Monet.map!(result) end
-	end
+    result = Monet.query!("select 1 where false")
+    assert Monet.map(result) == {:ok, nil}
+    assert Monet.map!({:ok, result}) == nil
 
-	test "maps helper" do
-		result = Monet.query!("select 1 a, 2 b union all select 4, 5")
-		assert Monet.maps(result) == {:ok, [%{"a" => 1, "b" => 2}, %{"a" => 4, "b" => 5}]}
-		assert Monet.maps({:ok, result}, columns: :atoms) == {:ok, [%{a: 1, b: 2}, %{a: 4, b: 5}]}
-		assert Monet.maps!(result, columns: :atoms) == [%{a: 1, b: 2}, %{a: 4, b: 5}]
-		assert Monet.maps!({:ok, result}) == [%{"a" => 1, "b" => 2}, %{"a" => 4, "b" => 5}]
+    result = Monet.query!("select 1, 2 union all select 3, 4")
 
-		result = Monet.query!("select 1 where false")
-		assert Monet.maps(result) == {:ok, []}
-		assert Monet.maps!({:ok, result}) == []
-	end
+    assert Monet.map(result) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "map called but multiple rows returned",
+                source: :client
+              }}
 
-	test "scalar helper" do
-		result = Monet.query!("select 9001")
-		assert Monet.scalar(result) == {:ok, 9001}
-		assert Monet.scalar({:ok, result}) == {:ok, 9001}
-		assert Monet.scalar!(result) == 9001
-		assert Monet.scalar!({:ok, result}) == 9001
+    assert Monet.map({:ok, result}) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "map called but multiple rows returned",
+                source: :client
+              }}
 
-		result = Monet.query!("select 1 union all select 3")
-		assert Monet.scalar(result) == {:error, %Monet.Error{code: nil, details: nil, message: "scalar called but multiple rows returned", source: :client}}
-		assert Monet.scalar({:ok, result}) == {:error, %Monet.Error{code: nil, details: nil, message: "scalar called but multiple rows returned", source: :client}}
-		assert_raise Monet.Error, "client scalar called but multiple rows returned", fn -> Monet.scalar!(result) end
+    assert_raise Monet.Error, "client map called but multiple rows returned", fn ->
+      Monet.map!(result)
+    end
+  end
 
-		result = Monet.query!("select 1, 2")
-		assert Monet.scalar(result) == {:error, %Monet.Error{code: nil, details: nil, message: "scalar called but multiple columns returned", source: :client}}
-		assert Monet.scalar({:ok, result}) == {:error, %Monet.Error{code: nil, details: nil, message: "scalar called but multiple columns returned", source: :client}}
-		assert_raise Monet.Error, "client scalar called but multiple columns returned", fn -> Monet.scalar!(result) end
-	end
+  test "maps helper" do
+    result = Monet.query!("select 1 a, 2 b union all select 4, 5")
+    assert Monet.maps(result) == {:ok, [%{"a" => 1, "b" => 2}, %{"a" => 4, "b" => 5}]}
+    assert Monet.maps({:ok, result}, columns: :atoms) == {:ok, [%{a: 1, b: 2}, %{a: 4, b: 5}]}
+    assert Monet.maps!(result, columns: :atoms) == [%{a: 1, b: 2}, %{a: 4, b: 5}]
+    assert Monet.maps!({:ok, result}) == [%{"a" => 1, "b" => 2}, %{"a" => 4, "b" => 5}]
+
+    result = Monet.query!("select 1 where false")
+    assert Monet.maps(result) == {:ok, []}
+    assert Monet.maps!({:ok, result}) == []
+  end
+
+  test "scalar helper" do
+    result = Monet.query!("select 9001")
+    assert Monet.scalar(result) == {:ok, 9001}
+    assert Monet.scalar({:ok, result}) == {:ok, 9001}
+    assert Monet.scalar!(result) == 9001
+    assert Monet.scalar!({:ok, result}) == 9001
+
+    result = Monet.query!("select 1 union all select 3")
+
+    assert Monet.scalar(result) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "scalar called but multiple rows returned",
+                source: :client
+              }}
+
+    assert Monet.scalar({:ok, result}) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "scalar called but multiple rows returned",
+                source: :client
+              }}
+
+    assert_raise Monet.Error, "client scalar called but multiple rows returned", fn ->
+      Monet.scalar!(result)
+    end
+
+    result = Monet.query!("select 1, 2")
+
+    assert Monet.scalar(result) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "scalar called but multiple columns returned",
+                source: :client
+              }}
+
+    assert Monet.scalar({:ok, result}) ==
+             {:error,
+              %Monet.Error{
+                code: nil,
+                details: nil,
+                message: "scalar called but multiple columns returned",
+                source: :client
+              }}
+
+    assert_raise Monet.Error, "client scalar called but multiple columns returned", fn ->
+      Monet.scalar!(result)
+    end
+  end
 end

--- a/test/support/base.ex
+++ b/test/support/base.ex
@@ -1,40 +1,47 @@
 defmodule Monet.Tests.Base do
-	use ExUnit.CaseTemplate
-	import Monet.Connection, only: [connection: 1]
+  use ExUnit.CaseTemplate
+  import Monet.Connection, only: [connection: 1]
 
-	using do
-		quote do
-			import Monet.Tests.Base
-		end
-	end
+  using do
+    quote do
+      import Monet.Tests.Base
+    end
+  end
 
-	def start_fake_server(opts) do
-		{:ok, pid} = Monet.Tests.Server.start_link(port: 50_010)
-		{:ok, socket} = :gen_tcp.connect('127.0.0.1', 50_010, [packet: :raw, mode: :binary, active: false], 1_000)
-		Enum.each(opts, fn cmd -> GenServer.cast(pid, cmd) end)
-		connection(socket: socket)
-	end
+  def start_fake_server(opts) do
+    {:ok, pid} = Monet.Tests.Server.start_link(port: 50_010)
 
-	def get_echo() do
-		receive do
-			{:echo, data} -> data
-		after
-			500 -> raise "nothing echo'd"
-		end
-	end
+    {:ok, socket} =
+      :gen_tcp.connect('127.0.0.1', 50_010, [packet: :raw, mode: :binary, active: false], 1_000)
 
-	def connect(opts \\ []) do
-		opts = Keyword.merge([
-			pool_size: 3,
-			port: 50_000,
-			host: "127.0.0.1",
-			username: "monetdb",
-			password: "monetdb",
-			database: "elixir_test",
-			schema: "sys",
-			role: "monetdb"
-		], opts)
+    Enum.each(opts, fn cmd -> GenServer.cast(pid, cmd) end)
+    connection(socket: socket)
+  end
 
-		{:ok, _} = Monet.start_link(opts)
-	end
+  def get_echo() do
+    receive do
+      {:echo, data} -> data
+    after
+      500 -> raise "nothing echo'd"
+    end
+  end
+
+  def connect(opts \\ []) do
+    opts =
+      Keyword.merge(
+        [
+          pool_size: 3,
+          port: 50_000,
+          host: "127.0.0.1",
+          username: "monetdb",
+          password: "monetdb",
+          database: "elixir_test",
+          schema: "sys",
+          role: "monetdb"
+        ],
+        opts
+      )
+
+    {:ok, _} = Monet.start_link(opts)
+  end
 end

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -1,106 +1,145 @@
 defmodule Monet.Tests.Generator do
-	@utf8 "test/utf8.txt" |> File.read!()  |> String.codepoints() |> List.to_tuple()
-	@utf8_upper tuple_size(@utf8) - 1
+  @utf8 "test/utf8.txt" |> File.read!() |> String.codepoints() |> List.to_tuple()
+  @utf8_upper tuple_size(@utf8) - 1
 
-	def utf8(min, max) do
-		min = min - 1
-		length = :rand.uniform(max - min) + min
+  def utf8(min, max) do
+    min = min - 1
+    length = :rand.uniform(max - min) + min
 
-		1..length
-		|> Enum.map(fn _ -> elem(@utf8, :rand.uniform(@utf8_upper)) end)
-		|> :erlang.iolist_to_binary()
-	end
+    1..length
+    |> Enum.map(fn _ -> elem(@utf8, :rand.uniform(@utf8_upper)) end)
+    |> :erlang.iolist_to_binary()
+  end
 
-	def bool(), do: :rand.uniform(2) == 2
+  def bool(), do: :rand.uniform(2) == 2
 
-	def int(power) do
-		max = trunc(:math.pow(2, power - 1) - 1)
-		value = :rand.uniform(max)
+  def int(power) do
+    max = trunc(:math.pow(2, power - 1) - 1)
+    value = :rand.uniform(max)
 
-		case :rand.uniform(2) == 2 do
-			true -> -value
-			false -> value
-		end
-	end
+    case :rand.uniform(2) == 2 do
+      true -> -value
+      false -> value
+    end
+  end
 
-	def float(64) do
-		int(63) + :rand.uniform_real()
-	end
+  def float(64) do
+    int(63) + :rand.uniform_real()
+  end
 
-	def decimal() do
-		value =  Decimal.from_float(int(31) + :rand.uniform_real())
-		{value, Decimal.round(value, 3)}
-	end
+  def decimal() do
+    value = Decimal.from_float(int(31) + :rand.uniform_real())
+    {value, Decimal.round(value, 3)}
+  end
 
-	def date() do
-		days = :rand.uniform(3022424)
-		Date.add(~D[0001-01-01], days)
-	end
+  def date() do
+    days = :rand.uniform(3_022_424)
+    Date.add(~D[0001-01-01], days)
+  end
 
-	def time(3) do
-		ms = :rand.uniform(86399999)
-		time = Time.add(~T[00:00:00], ms, :millisecond)
-		{time, Time.truncate(time, :millisecond)}
-	end
+  def time(3) do
+    ms = :rand.uniform(86_399_999)
+    time = Time.add(~T[00:00:00], ms, :millisecond)
+    {time, Time.truncate(time, :millisecond)}
+  end
 
-	def time(6) do
-		ms = :rand.uniform(86399999)
-		t = Time.add(~T[00:00:00], ms, :millisecond)
-		{t, t}
-	end
+  def time(6) do
+    ms = :rand.uniform(86_399_999)
+    t = Time.add(~T[00:00:00], ms, :millisecond)
+    {t, t}
+  end
 
-	def time(nil) do
-		s = :rand.uniform(86399)
-		time = Time.add(~T[00:00:00], s, :second)
-		{time, Time.truncate(time, :second)}
-	end
+  def time(nil) do
+    s = :rand.uniform(86399)
+    time = Time.add(~T[00:00:00], s, :second)
+    {time, Time.truncate(time, :second)}
+  end
 
-	def naivedatetime(n) do
-		d = date()
-		{t_in, t_out} = time(n)
-		{elem(NaiveDateTime.new(d, t_in), 1), elem(NaiveDateTime.new(d, t_out), 1)}
-	end
+  def naivedatetime(n) do
+    d = date()
+    {t_in, t_out} = time(n)
+    {elem(NaiveDateTime.new(d, t_in), 1), elem(NaiveDateTime.new(d, t_out), 1)}
+  end
 
-	def datetime(n) do
-		{n_in, n_out} = naivedatetime(n)
-		offset = :rand.uniform(20) * 1800
-		offset = case :rand.uniform(2) == 2 do
-			true -> -offset
-			false -> offset
-		end
-		input = %{DateTime.from_naive!(n_in, "Etc/UTC") | utc_offset: offset}
-		output = DateTime.from_naive!(NaiveDateTime.add(n_out, -offset), "Etc/UTC")
-		{input, output}
-	end
+  def datetime(n) do
+    {n_in, n_out} = naivedatetime(n)
+    offset = :rand.uniform(20) * 1800
 
-	def blob(), do: :crypto.strong_rand_bytes(:rand.uniform(2))
-	def json(), do: Jason.encode!(%{name: utf8(1, 20), n: int(16)})
-	def uuid() do
-		bin = :crypto.strong_rand_bytes(16)
-		<<a1::4, a2::4, a3::4, a4::4, a5::4, a6::4, a7::4, a8::4, b1::4, b2::4, b3::4, b4::4, c1::4, c2::4, c3::4, c4::4, d1::4, d2::4, d3::4, d4::4, e1::4, e2::4, e3::4, e4::4, e5::4, e6::4, e7::4, e8::4, e9::4, e10::4, e11::4, e12::4>> = bin
-		<<
-			e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-,
-			e(b1), e(b2), e(b3), e(b4), ?-,
-			e(c1), e(c2), e(c3), e(c4), ?-,
-			e(d1), e(d2), e(d3), e(d4), ?-,
-			e(e1), e(e2), e(e3), e(e4), e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12)
-		>>
-	end
+    offset =
+      case :rand.uniform(2) == 2 do
+        true -> -offset
+        false -> offset
+      end
 
-	defp e(0), do: ?0
-	defp e(1), do: ?1
-	defp e(2), do: ?2
-	defp e(3), do: ?3
-	defp e(4), do: ?4
-	defp e(5), do: ?5
-	defp e(6), do: ?6
-	defp e(7), do: ?7
-	defp e(8), do: ?8
-	defp e(9), do: ?9
-	defp e(10), do: ?a
-	defp e(11), do: ?b
-	defp e(12), do: ?c
-	defp e(13), do: ?d
-	defp e(14), do: ?e
-	defp e(15), do: ?f
+    input = %{DateTime.from_naive!(n_in, "Etc/UTC") | utc_offset: offset}
+    output = DateTime.from_naive!(NaiveDateTime.add(n_out, -offset), "Etc/UTC")
+    {input, output}
+  end
+
+  def blob(), do: :crypto.strong_rand_bytes(:rand.uniform(2))
+  def json(), do: Jason.encode!(%{name: utf8(1, 20), n: int(16)})
+
+  def uuid() do
+    bin = :crypto.strong_rand_bytes(16)
+
+    <<a1::4, a2::4, a3::4, a4::4, a5::4, a6::4, a7::4, a8::4, b1::4, b2::4, b3::4, b4::4, c1::4,
+      c2::4, c3::4, c4::4, d1::4, d2::4, d3::4, d4::4, e1::4, e2::4, e3::4, e4::4, e5::4, e6::4,
+      e7::4, e8::4, e9::4, e10::4, e11::4, e12::4>> = bin
+
+    <<
+      e(a1),
+      e(a2),
+      e(a3),
+      e(a4),
+      e(a5),
+      e(a6),
+      e(a7),
+      e(a8),
+      ?-,
+      e(b1),
+      e(b2),
+      e(b3),
+      e(b4),
+      ?-,
+      e(c1),
+      e(c2),
+      e(c3),
+      e(c4),
+      ?-,
+      e(d1),
+      e(d2),
+      e(d3),
+      e(d4),
+      ?-,
+      e(e1),
+      e(e2),
+      e(e3),
+      e(e4),
+      e(e5),
+      e(e6),
+      e(e7),
+      e(e8),
+      e(e9),
+      e(e10),
+      e(e11),
+      e(e12)
+    >>
+  end
+
+  defp e(0), do: ?0
+  defp e(1), do: ?1
+  defp e(2), do: ?2
+  defp e(3), do: ?3
+  defp e(4), do: ?4
+  defp e(5), do: ?5
+  defp e(6), do: ?6
+  defp e(7), do: ?7
+  defp e(8), do: ?8
+  defp e(9), do: ?9
+  defp e(10), do: ?a
+  defp e(11), do: ?b
+  defp e(12), do: ?c
+  defp e(13), do: ?d
+  defp e(14), do: ?e
+  defp e(15), do: ?f
 end

--- a/test/support/server.ex
+++ b/test/support/server.ex
@@ -1,61 +1,64 @@
 defmodule Monet.Tests.Server do
-	use GenServer
+  use GenServer
 
-	alias Monet.{Reader, Writer}
-	import Monet.Connection, only: [connection: 1]
+  alias Monet.{Reader, Writer}
+  import Monet.Connection, only: [connection: 1]
 
-	def start_link(opts) do
-		GenServer.start_link(__MODULE__, opts)
-	end
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
 
-	def init(opts) do
-		port = Keyword.fetch!(opts, :port)
-		{:ok, listener} = :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true, packet: :raw])
-		{:ok, listener, {:continue, :loop}}
-	end
+  def init(opts) do
+    port = Keyword.fetch!(opts, :port)
 
-	def handle_continue(:loop, listener) do
-		{:ok, socket} = :gen_tcp.accept(listener)
-		{:noreply, socket}
-	end
+    {:ok, listener} =
+      :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true, packet: :raw])
 
-	# raw, send as-is
-	def handle_cast({:say, data}, socket) do
-		:gen_tcp.send(socket, data)
-		{:noreply, socket}
-	end
+    {:ok, listener, {:continue, :loop}}
+  end
 
-	# send with a proper header
-	def handle_cast({:encode, data}, socket) do
-		Writer.send(connection(socket: socket), data)
-		{:noreply, socket}
-	end
+  def handle_continue(:loop, listener) do
+    {:ok, socket} = :gen_tcp.accept(listener)
+    {:noreply, socket}
+  end
 
-	def handle_cast({:echo, pid}, socket) do
-		res = Reader.message(connection(socket: socket))
-		send(pid, {:echo, res})
-		{:noreply, socket}
-	end
+  # raw, send as-is
+  def handle_cast({:say, data}, socket) do
+    :gen_tcp.send(socket, data)
+    {:noreply, socket}
+  end
 
-	def handle_cast({:reply, {nil, data}}, socket) do
-		# drain this message
-		Reader.message(connection(socket: socket))
+  # send with a proper header
+  def handle_cast({:encode, data}, socket) do
+    Writer.send(connection(socket: socket), data)
+    {:noreply, socket}
+  end
 
-		Writer.send(connection(socket: socket), data)
-		{:noreply, socket}
-	end
+  def handle_cast({:echo, pid}, socket) do
+    res = Reader.message(connection(socket: socket))
+    send(pid, {:echo, res})
+    {:noreply, socket}
+  end
 
-	# echo + encode
-	def handle_cast({:reply, {pid, data}}, socket) do
-		res = Reader.message(connection(socket: socket))
-		send(pid, {:echo, res})
+  def handle_cast({:reply, {nil, data}}, socket) do
+    # drain this message
+    Reader.message(connection(socket: socket))
 
-		Writer.send(connection(socket: socket), data)
-		{:noreply, socket}
-	end
+    Writer.send(connection(socket: socket), data)
+    {:noreply, socket}
+  end
 
-	def handle_cast({:close, true}, socket) do
-		:gen_tcp.close(socket)
-		{:noreply, nil}
-	end
+  # echo + encode
+  def handle_cast({:reply, {pid, data}}, socket) do
+    res = Reader.message(connection(socket: socket))
+    send(pid, {:echo, res})
+
+    Writer.send(connection(socket: socket), data)
+    {:noreply, socket}
+  end
+
+  def handle_cast({:close, true}, socket) do
+    :gen_tcp.close(socket)
+    {:noreply, nil}
+  end
 end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -1,99 +1,119 @@
 defmodule Monet.Tests.Transaction do
-	use Monet.Tests.Base
+  use Monet.Tests.Base
 
-	setup_all do
-		connect()
-		Monet.query!("drop table if exists tx_test")
-		Monet.query!("create table tx_test (id int)")
-		:ok
-	end
+  setup_all do
+    connect()
+    Monet.query!("drop table if exists tx_test")
+    Monet.query!("create table tx_test (id int)")
+    :ok
+  end
 
-	test "implicit commit" do
-		Monet.query!("truncate table tx_test")
+  test "implicit commit" do
+    Monet.query!("truncate table tx_test")
 
-		assert {:ok, result} = Monet.transaction(fn tx ->
-			Monet.query!(tx, "insert into tx_test values (?)", [3])
-			Monet.query(tx, "select * from tx_test")
-		end)
-		assert result.rows == [[3]]
-		assert Monet.query!("select * from tx_test").rows == [[3]]
-	end
+    assert {:ok, result} =
+             Monet.transaction(fn tx ->
+               Monet.query!(tx, "insert into tx_test values (?)", [3])
+               Monet.query(tx, "select * from tx_test")
+             end)
 
-	test "rollback" do
-		Monet.query!("truncate table tx_test")
+    assert result.rows == [[3]]
+    assert Monet.query!("select * from tx_test").rows == [[3]]
+  end
 
-		assert {:rollback, "fail"} = Monet.transaction(fn tx ->
-			Monet.query(tx, "insert into tx_test values (?)", 3)
-			{:rollback, "fail"}
-		end)
-		assert Monet.query!("select * from tx_test").rows == []
-	end
+  test "rollback" do
+    Monet.query!("truncate table tx_test")
 
-	test "rollback on raise" do
-		Monet.query!("truncate table tx_test")
-		assert_raise RuntimeError, fn ->
-			assert {:error, _} = Monet.transaction(fn tx ->
-				Monet.query(tx, "insert into tx_test values (?)", 3)
-				raise "fail"
-			end)
-		end
-		assert Monet.query!("select * from tx_test").rows == []
-	end
+    assert {:rollback, "fail"} =
+             Monet.transaction(fn tx ->
+               Monet.query(tx, "insert into tx_test values (?)", 3)
+               {:rollback, "fail"}
+             end)
 
-	test "prepares transactions" do
-		# Use a different pool because we want a pool_size of 1
-		# This is the only way to make sure the prepared statements are cleaned up
-		# after the transaction.
+    assert Monet.query!("select * from tx_test").rows == []
+  end
 
-		connect(pool_size: 1, name: :transaction_test)
-		Monet.query!("truncate table tx_test")
+  test "rollback on raise" do
+    Monet.query!("truncate table tx_test")
 
-		Monet.transaction!(:transaction_test, fn tx ->
-			Monet.prepare!(tx, :p1, "insert into tx_test (id) values (?)")
-			Monet.query!(tx, :p1, [1])
-			Monet.prepare!(tx, :p2, "insert into tx_test (id) values (?)")
-			Monet.query!(tx, :p2, [2])
-			Monet.query!(tx, :p1, [3])
-		end)
-		assert Monet.query!(:transaction_test, "select * from sys.prepared_statements").row_count == 0
-		assert Monet.query!(:transaction_test, "select * from tx_test order by id").rows == [[1], [2], [3]]
-		GenServer.stop(:transaction_test)
-	end
+    assert_raise RuntimeError, fn ->
+      assert {:error, _} =
+               Monet.transaction(fn tx ->
+                 Monet.query(tx, "insert into tx_test values (?)", 3)
+                 raise "fail"
+               end)
+    end
 
-	test "returns commit error" do
+    assert Monet.query!("select * from tx_test").rows == []
+  end
 
-		wait = fn ->
-			receive do
-				data -> data
-			after
-				100 -> raise "nothing received"
-			end
-		end
+  test "prepares transactions" do
+    # Use a different pool because we want a pool_size of 1
+    # This is the only way to make sure the prepared statements are cleaned up
+    # after the transaction.
 
-		pid = self()
-		fun = fn id ->
-			result = Monet.transaction(fn tx ->
-				wait.()
-				Monet.query!(tx, "insert into tx_test (id) values (1)")
-				wait.()
-			end)
-			send(pid, {id, result})
-		end
+    connect(pool_size: 1, name: :transaction_test)
+    Monet.query!("truncate table tx_test")
 
-		p1 = spawn fn -> fun.(1) end
-		p2 = spawn fn -> fun.(2) end
-		send(p1, :ok)
-		send(p2, :ok)
-		send(p1, :ok)
+    Monet.transaction!(:transaction_test, fn tx ->
+      Monet.prepare!(tx, :p1, "insert into tx_test (id) values (?)")
+      Monet.query!(tx, :p1, [1])
+      Monet.prepare!(tx, :p2, "insert into tx_test (id) values (?)")
+      Monet.query!(tx, :p2, [2])
+      Monet.query!(tx, :p1, [3])
+    end)
 
-		assert wait.() == {1, {:ok, :ok}}
-		send(p2, :ok)
-		assert wait.() == {2, {:error, %Monet.Error{
-			code: 40000,
-			details: nil,
-			message: "COMMIT: transaction is aborted because of concurrency conflicts, will ROLLBACK instead\n",
-			source: :monetd
-		}}}
+    assert Monet.query!(:transaction_test, "select * from sys.prepared_statements").row_count == 0
 
-	end
+    assert Monet.query!(:transaction_test, "select * from tx_test order by id").rows == [
+             [1],
+             [2],
+             [3]
+           ]
+
+    GenServer.stop(:transaction_test)
+  end
+
+  test "returns commit error" do
+    wait = fn ->
+      receive do
+        data -> data
+      after
+        100 -> raise "nothing received"
+      end
+    end
+
+    pid = self()
+
+    fun = fn id ->
+      result =
+        Monet.transaction(fn tx ->
+          wait.()
+          Monet.query!(tx, "insert into tx_test (id) values (1)")
+          wait.()
+        end)
+
+      send(pid, {id, result})
+    end
+
+    p1 = spawn(fn -> fun.(1) end)
+    p2 = spawn(fn -> fun.(2) end)
+    send(p1, :ok)
+    send(p2, :ok)
+    send(p1, :ok)
+
+    assert wait.() == {1, {:ok, :ok}}
+    send(p2, :ok)
+
+    assert wait.() ==
+             {2,
+              {:error,
+               %Monet.Error{
+                 code: 40000,
+                 details: nil,
+                 message:
+                   "COMMIT: transaction is aborted because of concurrency conflicts, will ROLLBACK instead\n",
+                 source: :monetd
+               }}}
+  end
 end

--- a/test/writer_test.exs
+++ b/test/writer_test.exs
@@ -1,56 +1,56 @@
 defmodule Monet.Tests.Writer do
-	use Monet.Tests.Base
-	alias Monet.Writer
+  use Monet.Tests.Base
+  alias Monet.Writer
 
-	test "writes nothing" do
-		conn = start_fake_server(echo: self())
-		Writer.send(conn, <<>>)
-		assert get_echo() == {:ok, <<>>}
-	end
+  test "writes nothing" do
+    conn = start_fake_server(echo: self())
+    Writer.send(conn, <<>>)
+    assert get_echo() == {:ok, <<>>}
+  end
 
-	test "writes single byte" do
-		conn = start_fake_server(echo: self())
-		Writer.send(conn, <<255>>)
-		assert get_echo() == {:ok, <<255>>}
-	end
+  test "writes single byte" do
+    conn = start_fake_server(echo: self())
+    Writer.send(conn, <<255>>)
+    assert get_echo() == {:ok, <<255>>}
+  end
 
-	test "writes max single-frame" do
-		msg = String.duplicate("1", 8190)
-		conn = start_fake_server(echo: self())
-		Writer.send(conn, msg)
-		assert get_echo() == {:ok, msg}
-	end
+  test "writes max single-frame" do
+    msg = String.duplicate("1", 8190)
+    conn = start_fake_server(echo: self())
+    Writer.send(conn, msg)
+    assert get_echo() == {:ok, msg}
+  end
 
-	test "writes max single-frame + 1" do
-		msg = String.duplicate("2", 8191)
-		conn = start_fake_server(echo: self())
-		Writer.send(conn, msg)
-		assert get_echo() == {:ok, msg}
-	end
+  test "writes max single-frame + 1" do
+    msg = String.duplicate("2", 8191)
+    conn = start_fake_server(echo: self())
+    Writer.send(conn, msg)
+    assert get_echo() == {:ok, msg}
+  end
 
-	test "writes max single-frame * 2" do
-		msg = String.duplicate("3", 16380)
-		conn = start_fake_server(echo: self())
-		Writer.send(conn, msg)
-		assert get_echo() == {:ok, msg}
-	end
+  test "writes max single-frame * 2" do
+    msg = String.duplicate("3", 16380)
+    conn = start_fake_server(echo: self())
+    Writer.send(conn, msg)
+    assert get_echo() == {:ok, msg}
+  end
 
-	test "writes max single-frame * 2 + 1" do
-		msg = String.duplicate("4", 16381)
-		conn = start_fake_server(echo: self())
-		Writer.send(conn, msg)
-		assert get_echo() == {:ok, msg}
-	end
+  test "writes max single-frame * 2 + 1" do
+    msg = String.duplicate("4", 16381)
+    conn = start_fake_server(echo: self())
+    Writer.send(conn, msg)
+    assert get_echo() == {:ok, msg}
+  end
 
-	test "writes a query" do
-		conn = start_fake_server(echo: self())
-		Writer.query(conn, "select power from goku")
-		assert get_echo() == {:ok, "sselect power from goku;"}
-	end
+  test "writes a query" do
+    conn = start_fake_server(echo: self())
+    Writer.query(conn, "select power from goku")
+    assert get_echo() == {:ok, "sselect power from goku;"}
+  end
 
-	test "writes a command" do
-		conn = start_fake_server(echo: self())
-		Writer.command(conn, "over 9000!")
-		assert get_echo() == {:ok, "Xover 9000!\n"}
-	end
+  test "writes a command" do
+    conn = start_fake_server(echo: self())
+    Writer.command(conn, "over 9000!")
+    assert get_echo() == {:ok, "Xover 9000!\n"}
+  end
 end


### PR DESCRIPTION
This PR refactors the HTML doc generation which includes:

- Use common source URL.
- Add link back to Github URL for function header.
- Fix incorrect license in module config.
- Fix HTML doc generation due to invalid indentation.
- Make `README` as default page in HTML doc.
- Badges and more badges.

Files within the module seems to be indented in the wrong way, which may explain why `ex_doc` may behave weirdly. Anyhow, I've added `.formatter.exs` file and `mix format` the whole module. HTML doc generation seems to work and display correctly in my machine.

Indentation issue.
![image](https://user-images.githubusercontent.com/134518/95463878-e6225780-09ab-11eb-9334-4fc5a13aba65.png)

Before.
![image](https://user-images.githubusercontent.com/134518/95463903-ed496580-09ab-11eb-9662-6fbb152aa985.png)

After.
![image](https://user-images.githubusercontent.com/134518/95463938-f6d2cd80-09ab-11eb-8b52-c227bd17d5cf.png)
